### PR TITLE
🐛fix: 단일 일정일 경우 if문으로 단순 리마인더.getTitle 반환 처리

### DIFF
--- a/src/main/java/com/project/backend/domain/reminder/service/query/ReminderQueryServiceImpl.java
+++ b/src/main/java/com/project/backend/domain/reminder/service/query/ReminderQueryServiceImpl.java
@@ -84,12 +84,16 @@ public class ReminderQueryServiceImpl implements ReminderQueryService{
         if (reminder.getTargetType() == TargetType.EVENT) {
             Event event = eventRepository.findById(reminder.getTargetId())
                     .orElseThrow(() -> new EventException(EventErrorCode.EVENT_NOT_FOUND));
-            log.info("111111");
+
+            // 단일 일정이면 RecurrenceException은 존재하지 않는다.
+            if (!event.isRecurring()) {
+                return reminder.getTitle();
+            }
+
             re = recurrenceExceptionRepository.findByRecurrenceGroupIdAndExceptionDate(
                     event.getRecurrenceGroup().getId(),
                     reminder.getOccurrenceTime().toLocalDate()
             );
-            log.info("re = " + reminder.getOccurrenceTime().toLocalDate());
         } else {
             // Todo 반복그룹 통합 필요
 //            Todo todo = todoRepository.findById(reminder.getTargetId())


### PR DESCRIPTION
# ☝️Issue Number

Close #66 

##  📌 개요

- 반복 없는 일정의 리마인더를 API를 통해 조회시, NullPointerException 에러 발견

## 🔁 변경 사항
- if문을 통해 반복 없는 일정은 RecurrenceException 확인 없이 바로 리마인더의 title 필드를 반환하도록 설정
## 📸 스크린샷

## 👀 기타 더 이야기해볼 점
