### PR TITLE
🐛fix: 리마인더 노출 구간 조회 쿼리 추가

### DIFF
--- a/src/main/java/com/project/backend/domain/reminder/repository/ReminderRepository.java
+++ b/src/main/java/com/project/backend/domain/reminder/repository/ReminderRepository.java
@@ -9,7 +9,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -17,16 +16,19 @@ import java.util.Optional;
 public interface ReminderRepository extends JpaRepository<Reminder, Long> {
 
     /**
-     * Reminder에 설정된 occurrenceTime이 현재 날짜이며, 현재시간보다 이후안 Reminder 가져오기
+     * 현재시간보다 이후이면서 현재시간 + 라마인더 설정시간보다 이전인 occurrenceTime을 가진 Reminder 가져오기
      */
-    List<Reminder> findByMemberIdAndLifecycleStatusAndOccurrenceTimeAfterAndOccurrenceTimeLessThanEqual(
-            Long memberId,
-            LifecycleStatus status,
-            LocalDateTime now,
-            LocalDateTime endOfToday
+    @Query("SELECT r " +
+            "FROM Reminder r " +
+            "WHERE r.member.id = :memberId " +
+            "AND r.lifecycleStatus = :status " +
+            "AND r.occurrenceTime >= :windowStart AND r.occurrenceTime <= :windowEnd ")
+    List<Reminder> findVisibleReminders(
+            @Param("memberId") Long memberId,
+            @Param("status") LifecycleStatus status,
+            @Param("windowStart") LocalDateTime windowStart,
+            @Param("windowEnd") LocalDateTime windowEnd
     );
-
-
 
     /**
      * 라이프 사이클(활성, 비활성)에 따른 Reminder 가져오기

--- a/src/main/java/com/project/backend/domain/reminder/service/query/ReminderQueryServiceImpl.java
+++ b/src/main/java/com/project/backend/domain/reminder/service/query/ReminderQueryServiceImpl.java
@@ -24,7 +24,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -49,14 +48,13 @@ public class ReminderQueryServiceImpl implements ReminderQueryService{
                 .orElseThrow(() -> new SettingException(SettingErrorCode.SETTING_NOT_FOUND));
 
         // 현재시간보다 저장된 리마인더의 occurrenceTime이 더 이후에 있는 리마인더만 반환 (이미 지나서 필요없는 리마인더 제외)
-        // 발생시간은 오늘인데 active하고, 현재시간이 안 지난 리마인더
         List<Reminder> reminders = reminderRepository.
-                findByMemberIdAndLifecycleStatusAndOccurrenceTimeAfterAndOccurrenceTimeLessThanEqual(
+                findVisibleReminders(
                         memberId,
                         LifecycleStatus.ACTIVE,
                         LocalDateTime.now(),
-                        LocalDate.now().atTime(23, 59, 59)
-                        );
+                        LocalDateTime.now().plusMinutes(setting.getReminderTiming().getMinutes())
+                );
 
         return reminders.stream()
                 .map(reminder ->


### PR DESCRIPTION
# ☝️Issue Number

Close #70 

##  📌 개요

- 리마인더 조회시, 리마인더 설정 값보다 이전인 리마인더도 조회됨

## 🔁 변경 사항
- 쿼리문 구체화하여 리마인더에 설정된 시간이 현재시간보다 이후이면서, 현재시간 + 리마인더 설정 시간보다 이전인 리마인더만 select하도록 설정 했습니다.

## 📸 스크린샷

## 👀 기타 더 이야기해볼 점
