### PR TITLE
♻️refactor/#82: updateEvent method 

### DIFF
--- a/src/main/java/com/project/backend/domain/event/controller/EventController.java
+++ b/src/main/java/com/project/backend/domain/event/controller/EventController.java
@@ -64,10 +64,11 @@ public class EventController implements EventDocs {
     public CustomResponse<Void> updateEvent(
             @AuthenticationPrincipal CustomUserDetails customUserDetails,
             @PathVariable Long eventId,
-            @RequestParam LocalDateTime originalDate,
+            @RequestParam LocalDateTime occurrenceDate,
+            @RequestParam(required = false) RecurrenceUpdateScope scope,
             @RequestBody EventReqDTO.UpdateReq req
     ){
-        eventCommandService.updateEvent(req, eventId, customUserDetails.getId(), originalDate);
+        eventCommandService.updateEvent(req, eventId, customUserDetails.getId(), scope, occurrenceDate);
         return CustomResponse.onSuccess("수정 완료", null);
     }
 

--- a/src/main/java/com/project/backend/domain/event/controller/EventDocs.java
+++ b/src/main/java/com/project/backend/domain/event/controller/EventDocs.java
@@ -617,6 +617,7 @@ public interface EventDocs {
                 ---
                 ## 🔁 반복 일정 수정 (recurrenceUpdateScope)
         
+                - 단일 일정인 경우 recurrenceUpdateScope는 필요하지 않습니다.
                 - 반복 일정인 경우 recurrenceUpdateScope는 필수입니다.
                 - 사용 가능 값:
                   - THIS_EVENT
@@ -693,14 +694,9 @@ public interface EventDocs {
                                             """
                             ),
 
-
                             // 2-1. 반복 없는 일정 수정 (단일 일정)
                             @ExampleObject(
                                     name = "단일 일정 수정",
-                                    description = """
-                                            반복이 없는 단일 일정 수정.
-                                            occurrenceDate는 전달하지 않습니다.
-                                            """,
                                     value = """
                                             {
                                               "title": "팀 회의 (변경)",
@@ -735,14 +731,11 @@ public interface EventDocs {
                                     description = """
                                             반복 일정 중 선택한 계산된 회차의 시간만 수정합니다.
                                             원본 일정은 THIS_EVENT 수정 불가능합니다.
-                                            실제 eventId를 가진 일정을 수정하는 것이 아니라 occurrenceDate는 필수입니다.
                                             """,
                                     value = """
                                             {
                                               "startTime": "2026-02-06T14:00:00",
-                                              "endTime": "2026-02-06T15:00:00",
-                                              "recurrenceUpdateScope": "THIS_EVENT"
-                                            }
+                                              "endTime": "2026-02-06T15:00:00"                                            }
                                             """
                             ),
                             // 3-2. 반복 일정 - 이 일정만 수정 (제목 변경)
@@ -751,12 +744,10 @@ public interface EventDocs {
                                     description = """
                                             반복 일정 중 선택한 계산된 회차의 제목만 수정합니다.
                                             원본 일정은 THIS_EVENT 수정 불가능합니다.
-                                            실제 eventId를 가진 일정을 수정하는 것이 아니라 occurrenceDate는 필수입니다.
                                             """,
                                     value = """
                                             {
-                                              "title": "특별 회의",
-                                              "recurrenceUpdateScope": "THIS_EVENT"
+                                              "title": "특별 회의"
                                             }
                                             """
                             ),
@@ -769,7 +760,6 @@ public interface EventDocs {
                                             """,
                                     value = """
                                             {
-                                              "recurrenceUpdateScope": "THIS_AND_FOLLOWING_EVENTS",
                                               "recurrenceGroup": {
                                                 "frequency": "WEEKLY",
                                                 "daysOfWeek": ["THURSDAY"],
@@ -789,7 +779,6 @@ public interface EventDocs {
                                             """,
                                     value = """
                                             {
-                                              "recurrenceUpdateScope": "THIS_AND_FOLLOWING_EVENTS",
                                               "recurrenceGroup": {
                                                 "frequency": "WEEKLY",
                                                 "daysOfWeek": ["MONDAY", "THURSDAY"],
@@ -1010,6 +999,13 @@ public interface EventDocs {
                     required = true
             )
             @RequestParam LocalDateTime occurrenceDate,
+
+            @Parameter(
+                    description = "반복 일정 수정 범위 (반복 할 일인 경우 필수)",
+                    schema = @Schema(allowableValues = {"THIS_EVENT", "THIS_AND_FOLLOWING_EVENTS"}),
+                    required = false
+            )
+            @RequestParam RecurrenceUpdateScope scope,
 
             @RequestBody
             @io.swagger.v3.oas.annotations.parameters.RequestBody(

--- a/src/main/java/com/project/backend/domain/event/dto/request/EventReqDTO.java
+++ b/src/main/java/com/project/backend/domain/event/dto/request/EventReqDTO.java
@@ -44,7 +44,6 @@ public class EventReqDTO {
             String location,
             EventColor color,
             Boolean isAllDay,
-            RecurrenceUpdateScope recurrenceUpdateScope,
             RecurrenceGroupReqDTO.UpdateReq recurrenceGroup
     ) {
     }

--- a/src/main/java/com/project/backend/domain/event/entity/RecurrenceException.java
+++ b/src/main/java/com/project/backend/domain/event/entity/RecurrenceException.java
@@ -3,6 +3,7 @@ package com.project.backend.domain.event.entity;
 import com.project.backend.domain.event.enums.EventColor;
 import com.project.backend.domain.event.enums.ExceptionType;
 import com.project.backend.domain.event.enums.RecurrenceFrequency;
+import com.project.backend.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -24,7 +25,7 @@ import java.util.Objects;
                         columnNames = {"recurrence_group_id", "exception_date"}
                 )
         })
-public class RecurrenceException {
+public class RecurrenceException extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/project/backend/domain/event/exception/EventErrorCode.java
+++ b/src/main/java/com/project/backend/domain/event/exception/EventErrorCode.java
@@ -21,7 +21,7 @@ public enum EventErrorCode implements BaseErrorCode {
     OCCURRENCE_DATE_REQUIRED(HttpStatus.BAD_REQUEST, "EVENT400_5", "OCCURRENCE_DATE가 없습니다."),
     UPDATE_SCOPE_REQUIRED(HttpStatus.BAD_REQUEST, "EVENT400_7", "UPDATE_SCOPE가 없습니다."),
     INVALID_UPDATE_SCOPE(HttpStatus.BAD_REQUEST, "EVENT400_8", "존재하지 않는UPDATE_SCOPE 값입니다."),
-    NOT_RECURRING_EVENT(HttpStatus.BAD_REQUEST, "EVENT400_9", "존재하지 않는UPDATE_SCOPE 값입니다.")
+    NOT_RECURRING_EVENT(HttpStatus.BAD_REQUEST, "EVENT400_9", "단일 일정입니다.")
     ;
 
 

--- a/src/main/java/com/project/backend/domain/event/service/EventOccurrenceResolver.java
+++ b/src/main/java/com/project/backend/domain/event/service/EventOccurrenceResolver.java
@@ -46,11 +46,6 @@ public class EventOccurrenceResolver {
     }
 
     private ResolvedOccurrence resolveInternal(Event event, LocalDateTime occurrenceDate) {
-        // 반복 + 일정이 아닌경우
-        if (!event.isRecurring()) {
-            throw new EventException(EventErrorCode.NOT_RECURRING_EVENT);
-        }
-
         // occurrenceDate가 수정/삭제된 일정의 태생적 날짜+시간 인지
         Optional<RecurrenceException> exception = recurrenceExceptionRepository.
                 findByRecurrenceGroupIdAndExceptionDate(event.getRecurrenceGroup().getId(), occurrenceDate);

--- a/src/main/java/com/project/backend/domain/event/service/command/EventCommandService.java
+++ b/src/main/java/com/project/backend/domain/event/service/command/EventCommandService.java
@@ -11,7 +11,13 @@ public interface EventCommandService {
 
     EventResDTO.CreateRes createEvent(EventReqDTO.CreateReq req, Long memberId);
 
-    void updateEvent(EventReqDTO.UpdateReq req, Long eventId, Long memberId, LocalDateTime originalDate);
+    void updateEvent
+            (EventReqDTO.UpdateReq req,
+             Long eventId,
+             Long memberId,
+             RecurrenceUpdateScope scope,
+             LocalDateTime originalDate
+            );
 
     void deleteEvent(Long eventId, LocalDateTime occurrenceDate, RecurrenceUpdateScope scope, Long memberId);
 }

--- a/src/main/java/com/project/backend/domain/event/service/command/EventCommandServiceImpl.java
+++ b/src/main/java/com/project/backend/domain/event/service/command/EventCommandServiceImpl.java
@@ -100,11 +100,9 @@ public class EventCommandServiceImpl implements EventCommandService {
                 .orElseThrow(() -> new EventException(EventErrorCode.EVENT_NOT_FOUND));
 
         eventValidator.validateUpdate(req, event, occurrenceDate);
-        // occurrenceDate가 존재하는 일정의 계산된 날짜인지
-        eventOccurrenceResolver.assertOccurrenceExists(event, occurrenceDate);
 
         // 수정안한 계산된 일정의 날짜인지, 수정된 날짜인지 계산
-        LocalDateTime start = calStartTime(req, event, occurrenceDate);
+        LocalDateTime start = event.isRecurring() ? calStartTime(req, event, occurrenceDate): event.getStartTime();
         LocalDateTime end = calEndTime(req, event, start, occurrenceDate);
 
         eventValidator.validateTime(start, end);

--- a/src/main/java/com/project/backend/domain/event/validator/EventValidator.java
+++ b/src/main/java/com/project/backend/domain/event/validator/EventValidator.java
@@ -21,9 +21,9 @@ public class EventValidator {
         validateMother(event, time);
     }
 
-    public void validateUpdate(EventReqDTO.UpdateReq req, Event event, LocalDateTime occurrenceDate) {
-        validateOccurrenceDate(occurrenceDate);
-        validateScope(event, occurrenceDate, req.recurrenceUpdateScope());
+    public void validateUpdate(Event event, LocalDateTime occurrenceDate, RecurrenceUpdateScope scope) {
+        validateOccurrenceDate(event, occurrenceDate);
+        validateScope(event, occurrenceDate, scope);
     }
 
     public void validateDelete(
@@ -31,7 +31,7 @@ public class EventValidator {
             LocalDateTime occurrenceDate,
             RecurrenceUpdateScope scope
     ) {
-        validateOccurrenceDate(occurrenceDate);
+        validateOccurrenceDate(event, occurrenceDate);
         validateScope(event, occurrenceDate, scope);
     }
 
@@ -55,9 +55,14 @@ public class EventValidator {
         }
     }
 
-    private void validateOccurrenceDate(LocalDateTime occurrenceDate) {
+    private void validateOccurrenceDate(Event event, LocalDateTime occurrenceDate) {
         if (occurrenceDate == null) {
             throw new EventException(EventErrorCode.OCCURRENCE_DATE_REQUIRED);
+        }
+
+        // 단일 일정인데, occurrenceDate가 event의 starTime과 일치하지 않을 경우
+        if (!event.isRecurring() && !occurrenceDate.isEqual(event.getStartTime())) {
+            throw new EventException(EventErrorCode.EVENT_NOT_FOUND);
         }
     }
 
@@ -67,7 +72,6 @@ public class EventValidator {
             RecurrenceUpdateScope scope
     ) {
         boolean isRecurring = event.getRecurrenceGroup() != null;
-
         // 단일 일정의 원본 삭제인 경우
         if (!isRecurring && scope != null) {
             throw new EventException(EventErrorCode.UPDATE_SCOPE_NOT_REQUIRED);


### PR DESCRIPTION
# ☝️Issue Number

Close #82 

##  📌 개요
d8b1cc98a2b77c2272a23b74ba3ce31a7de18d5d
- ♻️refactor: updateEvent 메서드 단일 일정 에러 문제 해결

2dcf431fbd59b0d2ee690b0a89fd45558f28711f
- ♻️refactor: updateScope를 requestParam으로 설정

440f0ca962b88cea67a2344303b79278bf7afbc2
- ♻️refactor: 단일 일정 수정시, occurrenceDate 불일치 시, 예외처리 설정

## 🔁 변경 사항

1. 단일 일정 수정 시, 입력한 occurrenceDate가 해당 일정의 startTime과 일치하는지 검증로직을 따로 처리하도록 validatorOccurrenceDate 메서드에 추가하고, 
// occurrenceDate가 존재하는 일정의 계산된 날짜인지
eventOccurrenceResolver.assertOccurrenceExists(event, occurrenceDate); 를 뒤에 위치 시켰습니다.

2. 일정 삭제와, 투두 수정,삭제와 통일성을 위해 occurrenceDate를 RequestParam으로 뺏습니다.

+ recurrenceException에 baseEntity를 extends 처리해서 main에 머지시 테이블 업데이트 해야합니다!

## 📸 스크린샷

## 👀 기타 더 이야기해볼 점
-> 급하게 발견하여 바로 수정적용했습니다. 확인하시고 문제 없으면 바로 main에 머지해주시면 될거같아요! (프론트 분들 작업할 수 있게 약속 다녀와서 오늘 새벽 6시에 끝냈습니다... 자느라 리뷰 approve를 빨리 못 볼거같아서 만약 문제 없다면 main에 머지하고 노션 변경사항 문서를 프론트분들께 전달해주실 수 있을까요..?)