### PR TITLE
🐛Fix: Todo isAllDay NPE해결(#91)

### DIFF
--- a/src/main/java/com/project/backend/domain/todo/service/command/TodoCommandServiceImpl.java
+++ b/src/main/java/com/project/backend/domain/todo/service/command/TodoCommandServiceImpl.java
@@ -76,7 +76,7 @@ public class TodoCommandServiceImpl implements TodoCommandService {
                 memberId,
                 todo.getTitle(),
                 recurrenceGroup != null,
-                todo.getStartDate().atTime(todo.getDueTime()),
+                todo.getDueTime() != null ? todo.getStartDate().atTime(todo.getDueTime()) : todo.getStartDate().atStartOfDay(),
                 ChangeType.CREATED
         );
         return TodoConverter.toTodoInfo(todo);
@@ -97,7 +97,7 @@ public class TodoCommandServiceImpl implements TodoCommandService {
                     memberId,
                     todo.getTitle(),
                     false,
-                    todo.getStartDate().atTime(todo.getDueTime()),
+                    todo.getDueTime() != null ? todo.getStartDate().atTime(todo.getDueTime()) : todo.getStartDate().atStartOfDay(),
                     ChangeType.UPDATE_SINGLE
             );
             return TodoConverter.toTodoInfo(todo);

--- a/src/main/java/com/project/backend/domain/todo/service/command/TodoCommandServiceImpl.java
+++ b/src/main/java/com/project/backend/domain/todo/service/command/TodoCommandServiceImpl.java
@@ -135,7 +135,7 @@ public class TodoCommandServiceImpl implements TodoCommandService {
             reminderEventBridge.handleReminderDeleted(
                     null,
                     memberId,
-                    occurrenceDate.atTime(todo.getDueTime()),
+                    todo.getDueTime() != null ? occurrenceDate.atTime(todo.getDueTime()) : occurrenceDate.atStartOfDay(),
                     todoId,
                     TargetType.TODO,
                     DeletedType.DELETED_SINGLE);
@@ -463,7 +463,7 @@ public class TodoCommandServiceImpl implements TodoCommandService {
     private void deleteThisTodoOnly(Todo todo, LocalDate occurrenceDate, Long memberId) {
         TodoRecurrenceGroup group = todo.getTodoRecurrenceGroup();
 
-        LocalDateTime startTime = occurrenceDate.atTime(todo.getDueTime());
+        LocalDateTime startTime = todo.getDueTime() != null ? occurrenceDate.atTime(todo.getDueTime()) : occurrenceDate.atStartOfDay();
 
         Optional<TodoRecurrenceException> re = todoRecurrenceExceptionRepository
                 .findByTodoRecurrenceGroupIdAndExceptionDate(group.getId(), occurrenceDate);
@@ -521,7 +521,7 @@ public class TodoCommandServiceImpl implements TodoCommandService {
         Optional<TodoRecurrenceException> re = todoRecurrenceExceptionRepository.
                 findByTodoRecurrenceGroupIdAndExceptionDate(group.getId(), occurrenceDate);
 
-        LocalDateTime startDate = occurrenceDate.atTime(todo.getDueTime());
+        LocalDateTime startDate = todo.getDueTime() != null ? occurrenceDate.atTime(todo.getDueTime()) : occurrenceDate.atStartOfDay();
 
         // 수정/삭제된 할 일일때
         if (re.isPresent()) {


### PR DESCRIPTION
# ☝️Issue Number

Close #91 

##  📌 개요
https://github.com/2026-Capstone-Project/BackEnd/commit/a04f1c1f11f76bd7c27c93950718b49c866308bc
- TodoCommandService에서 isAllDay=true일 때 NPE 해결

https://github.com/2026-Capstone-Project/BackEnd/commit/350c266ecbff68097d27c5ff753920b0b67d8ae6
- isAllDay=true로 저장된 todo(dueTime=null)를 삭제할 때 NPE가 날 수 있는 지점 수정

## 🔁 변경 사항
dueTime이 null이면 (isAllDay=true 케이스) atStartOfDay() (자정 00:00)으로 fallback 처리:
  - createTodo - 79번 줄
  - updateTodo (단일 수정) - 100번 줄
  - deleteTodo (단일 삭제) - 138번 줄
  - deleteThisTodoOnly - 466번 줄
  - deleteThisAndFollowing - 524번 줄

## 📸 스크린샷

## 👀 기타 더 이야기해볼 점
