### PR TITLE
반복 그룹 선제적 제안 생성 방식 수정

### DIFF
--- a/src/main/java/com/project/backend/domain/suggestion/service/command/SuggestionCommandServiceImpl.java
+++ b/src/main/java/com/project/backend/domain/suggestion/service/command/SuggestionCommandServiceImpl.java
@@ -346,7 +346,8 @@ public class SuggestionCommandServiceImpl implements SuggestionCommandService {
                 continue;
             }
             // 마지막 반복이 시작되는 날로부터 7일전이 아니면 생성할 시점이 아님
-            if (!last.toLocalDate().isEqual(now.plusDays(7))) {
+            Integer leadDays = SuggestionAnchorUtil.computeLeadDays(candidate);
+            if (!last.toLocalDate().isEqual(now.plusDays(leadDays))) {
                 continue;
             }
             // LLM 요청 바디에 추가

--- a/src/main/java/com/project/backend/domain/suggestion/util/SuggestionAnchorUtil.java
+++ b/src/main/java/com/project/backend/domain/suggestion/util/SuggestionAnchorUtil.java
@@ -1,6 +1,8 @@
 package com.project.backend.domain.suggestion.util;
 
+import com.project.backend.domain.event.enums.RecurrenceFrequency;
 import com.project.backend.domain.suggestion.enums.RecurrencePatternType;
+import com.project.backend.domain.suggestion.vo.RecurrenceSuggestionCandidate;
 import com.project.backend.domain.suggestion.vo.SuggestionPattern;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
@@ -82,6 +84,16 @@ public final class SuggestionAnchorUtil {
             return Math.min(dayDiff, 7);
         }
         return 7;
+    }
+
+    public static Integer computeLeadDays(
+            RecurrenceSuggestionCandidate candidate
+    ) {
+        if (candidate.getFrequency() == RecurrenceFrequency.DAILY) {
+            return Math.min(candidate.getIntervalValue(), 7);
+        } else {
+            return 7;
+        }
     }
 
     private static LocalDate fromEpochWeekStart(long epochWeek) {


### PR DESCRIPTION
# ☝️Issue Number

Close #93 

##  📌 개요

- e0351e130d6fb91426440098a52990064f557f58
  - 기존에는 반복 그룹이라면 7일 이전에 제안을 생성하였음
  - 그러나 반복 주기가 7일 미만인 경우에는 제안이 생성되지 않는 케이스가 존재
  - 따라서 반복 그룹의 반복이 DAILY일 때, 해당 반복 주기가 7일 미만이라면 해당 반복 주기를 고려하여 선제적 제안 생성 시간을 동적으로 변경

## 🔁 변경 사항

## 📸 스크린샷

## 👀 기타 더 이야기해볼 점
