### PR TITLE
Refactor/#89 WeekDayRule 입력에 따른 dayOfWeekInMonth 필드 값 추론 적용 로직

### DIFF
--- a/src/main/java/com/project/backend/domain/common/plan/enums/MonthlyWeekdayRule.java
+++ b/src/main/java/com/project/backend/domain/common/plan/enums/MonthlyWeekdayRule.java
@@ -1,4 +1,4 @@
-package com.project.backend.domain.event.enums;
+package com.project.backend.domain.common.plan.enums;
 
 public enum MonthlyWeekdayRule {
     SINGLE,      // 특정 요일 1개

--- a/src/main/java/com/project/backend/domain/common/plan/factory/PlanEventFactory.java
+++ b/src/main/java/com/project/backend/domain/common/plan/factory/PlanEventFactory.java
@@ -1,4 +1,4 @@
-package com.project.backend.domain.common.plan;
+package com.project.backend.domain.common.plan.factory;
 
 import com.project.backend.domain.common.reminder.dto.PlanChanged;
 import com.project.backend.domain.common.reminder.dto.RecurrenceExceptionChanged;

--- a/src/main/java/com/project/backend/domain/common/reminder/bridge/ReminderEventBridge.java
+++ b/src/main/java/com/project/backend/domain/common/reminder/bridge/ReminderEventBridge.java
@@ -1,6 +1,6 @@
 package com.project.backend.domain.common.reminder.bridge;
 
-import com.project.backend.domain.common.plan.PlanEventFactory;
+import com.project.backend.domain.common.plan.factory.PlanEventFactory;
 import com.project.backend.domain.reminder.enums.ChangeType;
 import com.project.backend.domain.reminder.enums.DeletedType;
 import com.project.backend.domain.reminder.enums.ExceptionChangeType;

--- a/src/main/java/com/project/backend/domain/event/controller/EventDocs.java
+++ b/src/main/java/com/project/backend/domain/event/controller/EventDocs.java
@@ -67,13 +67,13 @@ public interface EventDocs {
                 ## 📌 recurrenceGroup 필드 (CreateReq 기준)
                 
                 ### 공통 필드
-                - frequency (RecurrenceFrequency) ✅
+                - frequency (RecurrenceFrequency) 
                   - DAILY / WEEKLY / MONTHLY / YEARLY
                 
-                - intervalValue (Integer) ❌
+                - intervalValue (Integer) 
                   - 기본값 1 (생략 가능)
                 
-                - endType (RecurrenceEndType) ❌
+                - endType (RecurrenceEndType) 
                   - NEVER / END_BY_DATE / END_BY_COUNT
                   - null로 보내면 NEVER로 저장됩니다.
                   - endType이 null인 경우 endDate, occurrenceCount도 반드시 null이어야 합니다.
@@ -90,33 +90,33 @@ public interface EventDocs {
                 
                 ---
                 ### WEEKLY (매주 반복)
-                - daysOfWeek (List<DayOfWeek>) ❌
+                - daysOfWeek (List<DayOfWeek>) 
                   - 예: ["MONDAY", "WEDNESDAY", "FRIDAY"]
                   - null로 보내면 일정의 startTime 기준 요일로 자동 설정됩니다.
                 
                 ---
                 ### MONTHLY (매월 반복)
-                - monthlyType (MonthlyType) ❌
+                - monthlyType (MonthlyType)
                   - DAY_OF_MONTH : 매월 N일
                   - DAY_OF_WEEK  : 매월 N번째 X요일
                   - null로 보내면 DAY_OF_MONTH로 저장됩니다.
                 
-                - weekdayRule (MonthlyWeekdayRule) ❌
-                  - SINGLE / WEEKDAY / WEEKEND / ALL_DAYS
-                  - null로 보내면 SINGLE로 저장됩니다.
-                
                 #### monthlyType = DAY_OF_MONTH (매월 N일)
-                - daysOfMonth (List<Integer>) ❌
+                - daysOfMonth (List<Integer>) 
                   - 1~31
                   - null이면 startTime 기준 '일'로 자동 설정됩니다.
                   - 예: [15], [15, 30]
                 
                 #### monthlyType = DAY_OF_WEEK (매월 N번째 X요일)
-                - weekOfMonth (Integer) ✅
+                - weekOfMonth (Integer) 
                   - 1~5
                   - null이면 startTime 기준 주차로 자동 설정됩니다.
                 
-                - dayOfWeekInMonth (List<DayOfWeek>) ✅
+                - weekdayRule (MonthlyWeekdayRule) 
+                  - SINGLE / WEEKDAY / WEEKEND / ALL_DAYS
+                  - null로 보내면 SINGLE로 저장됩니다.
+                  
+                - dayOfWeekInMonth (List<DayOfWeek>) 
                   - 예: ["TUESDAY"]
                   - **요일은 하나만 입력 가능합니다.** (리스트 길이 1만 허용)
                   - null이면 startTime 기준 요일로 자동 설정됩니다.
@@ -127,7 +127,7 @@ public interface EventDocs {
                 
                 ---
                 ### YEARLY (매년 반복)
-                - monthOfYear (Integer) ❌
+                - monthOfYear (Integer) 
                   - 1~12
                   - null이면 startTime 기준 월로 자동 설정됩니다.
                 

--- a/src/main/java/com/project/backend/domain/event/controller/EventDocs.java
+++ b/src/main/java/com/project/backend/domain/event/controller/EventDocs.java
@@ -633,6 +633,7 @@ public interface EventDocs {
                 - 선택한 occurrenceDate(태생) 회차와 그 이후를 수정합니다.
                 - 기존 반복 그룹은 occurrenceDate 이전까지만 유지됩니다.
                 - occurrenceDate는 새 반복의 기준점(base)이 됩니다.
+                - 반복 일정을 대상으로 반복 관련 필드를 수정하는 경우 THIS_AND_FOLLOWING_EVENTS를 통해서만 수정가능합니다.
                 ---
                 ## ⏱️ 시간(startTime / endTime) 처리 규칙 (업데이트)
                 

--- a/src/main/java/com/project/backend/domain/event/controller/EventDocs.java
+++ b/src/main/java/com/project/backend/domain/event/controller/EventDocs.java
@@ -116,14 +116,20 @@ public interface EventDocs {
                   - SINGLE / WEEKDAY / WEEKEND / ALL_DAYS
                   - null로 보내면 SINGLE로 저장됩니다.
                   
-                - dayOfWeekInMonth (List<DayOfWeek>) 
-                  - 예: ["TUESDAY"]
-                  - **요일은 하나만 입력 가능합니다.** (리스트 길이 1만 허용)
+                - dayOfWeekInMonth (DayOfWeek) 
+                  - 예: "TUESDAY"
+                  - **요일은 하나만 입력 가능합니다.**
                   - null이면 startTime 기준 요일로 자동 설정됩니다.
                 
-                ✅ 추가 제한 사항(중요)
-                - 현재 리마인더 문제로 인해 weekdayRule에 WEEKDAY / WEEKEND / ALL_DAYS 값을 입력하여 일정 생성 시 오류가 발생합니다.
-                - 따라서 현재는 weekdayRule을 **SINGLE 또는 null**로 보내서 생성해야 합니다.
+                **일정 생성, 수정시 weekDayRule 사용법**
+                
+                  **단일 요일**
+                  - 단일 요일 선택시에는 weekDayRule = SINGLE, dayOfWeekInMonth = "MONDAY" 입니다.
+                  - weekDayRule = SINGLE만 보내면, dayOfweekINMonth 값은 해당 일정의 startTime의 요일로 초기화됩니다.
+                  - dayOfWeekInMonth = "MONDAY"만 보내면, weekDayRule 값은 무조건 SINGLE로 초기화됩니다.
+                  
+                  **평일, 주말, 1주 전체**
+                  - weekDayRule = "WEEKDAY or WEEKEND or ALL_DAYS" 이면 dayOfWeekInMonth = null 입니다.
                 
                 ---
                 ### YEARLY (매년 반복)

--- a/src/main/java/com/project/backend/domain/event/controller/EventDocs.java
+++ b/src/main/java/com/project/backend/domain/event/controller/EventDocs.java
@@ -251,7 +251,7 @@ public interface EventDocs {
                                                 "frequency": "MONTHLY",
                                                 "monthlyType": "DAY_OF_WEEK",
                                                 "weekOfMonth": 2,
-                                                "dayOfWeekInMonth": ["TUESDAY"]
+                                                "dayOfWeekInMonth": "TUESDAY"
                                               }
                                             }
                                             """

--- a/src/main/java/com/project/backend/domain/event/converter/RecurrenceGroupConverter.java
+++ b/src/main/java/com/project/backend/domain/event/converter/RecurrenceGroupConverter.java
@@ -1,5 +1,6 @@
 package com.project.backend.domain.event.converter;
 
+import com.project.backend.domain.common.plan.enums.MonthlyWeekdayRule;
 import com.project.backend.domain.event.dto.request.EventReqDTO;
 import com.project.backend.domain.event.dto.request.RecurrenceGroupReqDTO;
 import com.project.backend.domain.event.dto.response.RecurrenceGroupResDTO;

--- a/src/main/java/com/project/backend/domain/event/converter/RecurrenceGroupConverter.java
+++ b/src/main/java/com/project/backend/domain/event/converter/RecurrenceGroupConverter.java
@@ -6,8 +6,6 @@ import com.project.backend.domain.event.dto.response.RecurrenceGroupResDTO;
 import com.project.backend.domain.event.entity.RecurrenceException;
 import com.project.backend.domain.event.entity.RecurrenceGroup;
 import com.project.backend.domain.event.enums.*;
-import com.project.backend.domain.event.exception.RecurrenceGroupErrorCode;
-import com.project.backend.domain.event.exception.RecurrenceGroupException;
 import com.project.backend.domain.member.entity.Member;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;

--- a/src/main/java/com/project/backend/domain/event/converter/RecurrenceGroupSpec.java
+++ b/src/main/java/com/project/backend/domain/event/converter/RecurrenceGroupSpec.java
@@ -20,7 +20,6 @@ public record RecurrenceGroupSpec(
         MonthlyType monthlyType,
         List<Integer> daysOfMonth,
         Integer weekOfMonth,
-        MonthlyWeekdayRule weekdayRule,
         List<DayOfWeek> dayOfWeekInMonth,
 
         Integer monthOfYear,

--- a/src/main/java/com/project/backend/domain/event/converter/RecurrenceGroupSpec.java
+++ b/src/main/java/com/project/backend/domain/event/converter/RecurrenceGroupSpec.java
@@ -1,7 +1,7 @@
 package com.project.backend.domain.event.converter;
 
 import com.project.backend.domain.event.enums.MonthlyType;
-import com.project.backend.domain.event.enums.MonthlyWeekdayRule;
+import com.project.backend.domain.common.plan.enums.MonthlyWeekdayRule;
 import com.project.backend.domain.event.enums.RecurrenceEndType;
 import com.project.backend.domain.event.enums.RecurrenceFrequency;
 import lombok.Builder;

--- a/src/main/java/com/project/backend/domain/event/dto/request/RecurrenceGroupReqDTO.java
+++ b/src/main/java/com/project/backend/domain/event/dto/request/RecurrenceGroupReqDTO.java
@@ -1,7 +1,7 @@
 package com.project.backend.domain.event.dto.request;
 
 import com.project.backend.domain.event.enums.MonthlyType;
-import com.project.backend.domain.event.enums.MonthlyWeekdayRule;
+import com.project.backend.domain.common.plan.enums.MonthlyWeekdayRule;
 import com.project.backend.domain.event.enums.RecurrenceEndType;
 import com.project.backend.domain.event.enums.RecurrenceFrequency;
 import jakarta.validation.constraints.Max;

--- a/src/main/java/com/project/backend/domain/event/dto/request/RecurrenceGroupReqDTO.java
+++ b/src/main/java/com/project/backend/domain/event/dto/request/RecurrenceGroupReqDTO.java
@@ -33,7 +33,7 @@ public class RecurrenceGroupReqDTO {
             @Max(5)
             Integer weekOfMonth,
             MonthlyWeekdayRule weekdayRule,
-            List<DayOfWeek> dayOfWeekInMonth,
+            DayOfWeek dayOfWeekInMonth,
 
             // YEARLY: 반복 월
             @Min(1)
@@ -72,7 +72,7 @@ public class RecurrenceGroupReqDTO {
             @Max(5)
             Integer weekOfMonth,
             MonthlyWeekdayRule weekdayRule,
-            List<DayOfWeek> dayOfWeekInMonth,
+            DayOfWeek dayOfWeekInMonth,
 
             // YEARLY: 반복 월
             @Min(1)

--- a/src/main/java/com/project/backend/domain/event/dto/response/RecurrenceGroupResDTO.java
+++ b/src/main/java/com/project/backend/domain/event/dto/response/RecurrenceGroupResDTO.java
@@ -6,6 +6,7 @@ import com.project.backend.domain.event.enums.RecurrenceEndType;
 import com.project.backend.domain.event.enums.RecurrenceFrequency;
 import lombok.Builder;
 
+import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.util.List;
 
@@ -18,13 +19,13 @@ public class RecurrenceGroupResDTO {
             Boolean isCustom,
             Integer interval,
 
-            List<String> daysOfWeek,
+            List<DayOfWeek> daysOfWeek,
 
             MonthlyType monthlyType,
             List<Integer> daysOfMonth,
             Integer weekOfMonth,
             MonthlyWeekdayRule weekdayRule,
-            List<String> dayOfWeekInMonth,
+            List<DayOfWeek> dayOfWeekInMonth,
 
             Integer monthOfYear,
 

--- a/src/main/java/com/project/backend/domain/event/dto/response/RecurrenceGroupResDTO.java
+++ b/src/main/java/com/project/backend/domain/event/dto/response/RecurrenceGroupResDTO.java
@@ -1,7 +1,7 @@
 package com.project.backend.domain.event.dto.response;
 
 import com.project.backend.domain.event.enums.MonthlyType;
-import com.project.backend.domain.event.enums.MonthlyWeekdayRule;
+import com.project.backend.domain.common.plan.enums.MonthlyWeekdayRule;
 import com.project.backend.domain.event.enums.RecurrenceEndType;
 import com.project.backend.domain.event.enums.RecurrenceFrequency;
 import lombok.Builder;

--- a/src/main/java/com/project/backend/domain/event/entity/Event.java
+++ b/src/main/java/com/project/backend/domain/event/entity/Event.java
@@ -7,6 +7,7 @@ import com.project.backend.domain.member.entity.Member;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.time.Duration;
 import java.time.LocalDateTime;
 
 @Entity
@@ -143,11 +144,17 @@ public class Event extends BaseEntity {
     ) {
         if (title != null) this.title = title;
         if (content != null) this.content = content;
-        if (startTime != null) this.startTime = startTime;
+        if (startTime != null) {
+            this.startTime = startTime;
+            this.endTime = startTime.plusMinutes(durationMinutes);
+        }
         if (endTime != null) this.endTime = endTime;
         if (location != null) this.location = location;
         if (color != null) this.color = color;
         if (isAllDay != null) this.isAllDay = isAllDay;
+        if (startTime != null && endTime != null) {
+            this.durationMinutes = (int) Duration.between(startTime, endTime).toMinutes();
+        }
     }
 
     public void updateRecurrenceGroup(RecurrenceGroup recurrenceGroup) {

--- a/src/main/java/com/project/backend/domain/event/entity/RecurrenceGroup.java
+++ b/src/main/java/com/project/backend/domain/event/entity/RecurrenceGroup.java
@@ -10,6 +10,7 @@ import com.project.backend.global.recurrence.RecurrenceRule;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Arrays;
@@ -50,10 +51,6 @@ public class RecurrenceGroup extends BaseEntity implements RecurrenceRule {
 
     @Column(name = "week_of_month")
     private Integer weekOfMonth;
-
-    @Enumerated(EnumType.STRING)
-    @Column(name = "monthly_weekday_rule", length = 20)
-    private MonthlyWeekdayRule monthlyWeekdayRule;
 
     @Column(name = "day_of_week_in_month", length = 60)
     private String dayOfWeekInMonth;
@@ -138,21 +135,11 @@ public class RecurrenceGroup extends BaseEntity implements RecurrenceRule {
         this.event = event;
     }
 
-    public List<String> getDaysOfWeekAsList() {
-        if (daysOfWeek == null) return null;
-        return List.of(daysOfWeek.split(","));
-    }
-
     public List<Integer> getDaysOfMonthAsList() {
         if (daysOfMonth == null) return null;
         return Arrays.stream(daysOfMonth.split(","))
                 .map(Integer::valueOf)
                 .toList();
-    }
-
-    public List<String> getDayOfWeekInMonthAsList() {
-        if (dayOfWeekInMonth == null) return null;
-        return List.of(dayOfWeekInMonth.split(","));
     }
 
     public void extendEndDate(long dayDiff) {

--- a/src/main/java/com/project/backend/domain/event/entity/RecurrenceGroup.java
+++ b/src/main/java/com/project/backend/domain/event/entity/RecurrenceGroup.java
@@ -1,7 +1,7 @@
 package com.project.backend.domain.event.entity;
 
 import com.project.backend.domain.event.enums.MonthlyType;
-import com.project.backend.domain.event.enums.MonthlyWeekdayRule;
+import com.project.backend.domain.common.plan.enums.MonthlyWeekdayRule;
 import com.project.backend.domain.event.enums.RecurrenceEndType;
 import com.project.backend.domain.event.enums.RecurrenceFrequency;
 import com.project.backend.domain.member.entity.Member;

--- a/src/main/java/com/project/backend/domain/event/exception/EventErrorCode.java
+++ b/src/main/java/com/project/backend/domain/event/exception/EventErrorCode.java
@@ -21,7 +21,9 @@ public enum EventErrorCode implements BaseErrorCode {
     OCCURRENCE_DATE_REQUIRED(HttpStatus.BAD_REQUEST, "EVENT400_5", "OCCURRENCE_DATE가 없습니다."),
     UPDATE_SCOPE_REQUIRED(HttpStatus.BAD_REQUEST, "EVENT400_7", "UPDATE_SCOPE가 없습니다."),
     INVALID_UPDATE_SCOPE(HttpStatus.BAD_REQUEST, "EVENT400_8", "존재하지 않는UPDATE_SCOPE 값입니다."),
-    NOT_RECURRING_EVENT(HttpStatus.BAD_REQUEST, "EVENT400_9", "단일 일정입니다.")
+    NOT_RECURRING_EVENT(HttpStatus.BAD_REQUEST, "EVENT400_9", "단일 일정입니다."),
+    THIS_AND_FOLLOWING_EVENTS_ONLY
+            (HttpStatus.BAD_REQUEST, "EVENT400_10", "반복 필드 수정 시, THIS_AND_FOLLOWING_EVENTS만 가능합니다.")
     ;
 
 

--- a/src/main/java/com/project/backend/domain/event/exception/EventErrorCode.java
+++ b/src/main/java/com/project/backend/domain/event/exception/EventErrorCode.java
@@ -23,7 +23,8 @@ public enum EventErrorCode implements BaseErrorCode {
     INVALID_UPDATE_SCOPE(HttpStatus.BAD_REQUEST, "EVENT400_8", "존재하지 않는UPDATE_SCOPE 값입니다."),
     NOT_RECURRING_EVENT(HttpStatus.BAD_REQUEST, "EVENT400_9", "단일 일정입니다."),
     THIS_AND_FOLLOWING_EVENTS_ONLY
-            (HttpStatus.BAD_REQUEST, "EVENT400_10", "반복 필드 수정 시, THIS_AND_FOLLOWING_EVENTS만 가능합니다.")
+            (HttpStatus.BAD_REQUEST, "EVENT400_10",
+                    "반복 필드 수정, 단일 일정 -> 반복 일정으로 수정 시, THIS_AND_FOLLOWING_EVENTS만 가능합니다.")
     ;
 
 

--- a/src/main/java/com/project/backend/domain/event/service/RecurrenceTimeAdjuster.java
+++ b/src/main/java/com/project/backend/domain/event/service/RecurrenceTimeAdjuster.java
@@ -2,7 +2,7 @@ package com.project.backend.domain.event.service;
 
 import com.project.backend.domain.event.converter.RecurrenceGroupSpec;
 import com.project.backend.domain.event.dto.AdjustedTime;
-import com.project.backend.domain.event.enums.MonthlyWeekdayRule;
+import com.project.backend.domain.common.plan.enums.MonthlyWeekdayRule;
 import com.project.backend.domain.event.enums.RecurrenceFrequency;
 import com.project.backend.domain.event.exception.RecurrenceGroupErrorCode;
 import com.project.backend.domain.event.exception.RecurrenceGroupException;

--- a/src/main/java/com/project/backend/domain/event/service/RecurrenceTimeAdjuster.java
+++ b/src/main/java/com/project/backend/domain/event/service/RecurrenceTimeAdjuster.java
@@ -6,6 +6,7 @@ import com.project.backend.domain.common.plan.enums.MonthlyWeekdayRule;
 import com.project.backend.domain.event.enums.RecurrenceFrequency;
 import com.project.backend.domain.event.exception.RecurrenceGroupErrorCode;
 import com.project.backend.domain.event.exception.RecurrenceGroupException;
+import com.project.backend.global.recurrence.util.RecurrenceUtils;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -150,7 +151,7 @@ public class RecurrenceTimeAdjuster {
             RecurrenceGroupSpec spec
     ) {
         int week = spec.weekOfMonth();
-        MonthlyWeekdayRule rule = spec.weekdayRule();
+        MonthlyWeekdayRule rule = RecurrenceUtils.inferWeekdayRule(spec.dayOfWeekInMonth());
 
         if (rule == null) {
             return base;

--- a/src/main/java/com/project/backend/domain/event/service/command/EventCommandServiceImpl.java
+++ b/src/main/java/com/project/backend/domain/event/service/command/EventCommandServiceImpl.java
@@ -115,7 +115,7 @@ public class EventCommandServiceImpl implements EventCommandService {
         eventValidator.validateUpdate(event, req.recurrenceGroup(), occurrenceDate, scope);
 
         // 수정안한 계산된 일정의 날짜인지, 수정된 날짜인지 계산
-        LocalDateTime start = event.isRecurring() ? calStartTime(req, event, occurrenceDate): event.getStartTime();
+        LocalDateTime start = calStartTime(req, event, occurrenceDate);
         LocalDateTime end = calEndTime(req, event, start, occurrenceDate);
 
         eventValidator.validateTime(start, end);
@@ -627,12 +627,14 @@ public class EventCommandServiceImpl implements EventCommandService {
             return req.startTime();
         }
 
-        Optional<RecurrenceException> re = recurrenceExRepository.
-                findByRecurrenceGroupIdAndExceptionDateAndExceptionType(
-                event.getRecurrenceGroup().getId(), occurrenceDate, ExceptionType.OVERRIDE
-        );
-        if (re.isPresent() && re.get().getStartTime() != null) {
-            return re.get().getStartTime();
+        if (event.isRecurring()) {
+            Optional<RecurrenceException> re = recurrenceExRepository.
+                    findByRecurrenceGroupIdAndExceptionDateAndExceptionType(
+                            event.getRecurrenceGroup().getId(), occurrenceDate, ExceptionType.OVERRIDE
+                    );
+            if (re.isPresent() && re.get().getStartTime() != null) {
+                return re.get().getStartTime();
+            }
         }
 
         return occurrenceDate;

--- a/src/main/java/com/project/backend/domain/event/service/command/EventCommandServiceImpl.java
+++ b/src/main/java/com/project/backend/domain/event/service/command/EventCommandServiceImpl.java
@@ -110,7 +110,7 @@ public class EventCommandServiceImpl implements EventCommandService {
         Event event = eventRepository.findByIdAndMemberId(eventId, memberId)
                 .orElseThrow(() -> new EventException(EventErrorCode.EVENT_NOT_FOUND));
 
-        eventValidator.validateUpdate(event, occurrenceDate, scope);
+        eventValidator.validateUpdate(event, req.recurrenceGroup(), occurrenceDate, scope);
 
         // 수정안한 계산된 일정의 날짜인지, 수정된 날짜인지 계산
         LocalDateTime start = event.isRecurring() ? calStartTime(req, event, occurrenceDate): event.getStartTime();

--- a/src/main/java/com/project/backend/domain/event/service/command/EventCommandServiceImpl.java
+++ b/src/main/java/com/project/backend/domain/event/service/command/EventCommandServiceImpl.java
@@ -14,7 +14,7 @@ import com.project.backend.domain.event.entity.RecurrenceException;
 import com.project.backend.domain.event.entity.RecurrenceGroup;
 import com.project.backend.domain.event.enums.EventColor;
 import com.project.backend.domain.event.enums.ExceptionType;
-import com.project.backend.domain.event.enums.MonthlyWeekdayRule;
+import com.project.backend.domain.common.plan.enums.MonthlyWeekdayRule;
 import com.project.backend.domain.event.enums.RecurrenceUpdateScope;
 import com.project.backend.domain.event.exception.EventErrorCode;
 import com.project.backend.domain.event.exception.EventException;

--- a/src/main/java/com/project/backend/domain/event/strategy/generator/monthlyrule/DayOfWeekRule.java
+++ b/src/main/java/com/project/backend/domain/event/strategy/generator/monthlyrule/DayOfWeekRule.java
@@ -1,6 +1,5 @@
 package com.project.backend.domain.event.strategy.generator.monthlyrule;
 
-import com.project.backend.domain.event.enums.MonthlyWeekdayRule;
 import com.project.backend.global.recurrence.RecurrenceRule;
 import com.project.backend.global.recurrence.util.RecurrenceUtils;
 import lombok.extern.slf4j.Slf4j;
@@ -10,7 +9,6 @@ import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.YearMonth;
-import java.time.temporal.WeekFields;
 import java.util.List;
 import java.util.Optional;
 

--- a/src/main/java/com/project/backend/domain/event/strategy/generator/monthlyrule/DayOfWeekRule.java
+++ b/src/main/java/com/project/backend/domain/event/strategy/generator/monthlyrule/DayOfWeekRule.java
@@ -37,7 +37,7 @@ public class DayOfWeekRule implements MonthlyRule {
             YearMonth targetMonth = baseMonth.plusMonths((long) interval * step);
 
             Optional<LocalDate> date =
-                    RecurrenceUtils.calculateMonthlyNthWeekday(targetMonth, weekOfMonth, targetDays);
+                    RecurrenceUtils.calculateMonthlyNthOrdinalWeekday(targetMonth, weekOfMonth, targetDays);
 
             if (date.isPresent()) {
                 return LocalDateTime.of(date.get(), current.toLocalTime());

--- a/src/main/java/com/project/backend/domain/event/validator/EventValidator.java
+++ b/src/main/java/com/project/backend/domain/event/validator/EventValidator.java
@@ -80,7 +80,7 @@ public class EventValidator {
     ) {
         boolean isRecurring = event.getRecurrenceGroup() != null;
         // 단일 일정의 원본 삭제인 경우
-        if (!isRecurring && scope != null) {
+        if (!isRecurring && req == null && scope != null) {
             throw new EventException(EventErrorCode.UPDATE_SCOPE_NOT_REQUIRED);
         }
 

--- a/src/main/java/com/project/backend/domain/event/validator/EventValidator.java
+++ b/src/main/java/com/project/backend/domain/event/validator/EventValidator.java
@@ -1,6 +1,7 @@
 package com.project.backend.domain.event.validator;
 
 import com.project.backend.domain.event.dto.request.EventReqDTO;
+import com.project.backend.domain.event.dto.request.RecurrenceGroupReqDTO;
 import com.project.backend.domain.event.entity.Event;
 import com.project.backend.domain.event.enums.RecurrenceUpdateScope;
 import com.project.backend.domain.event.exception.EventErrorCode;
@@ -21,9 +22,14 @@ public class EventValidator {
         validateMother(event, time);
     }
 
-    public void validateUpdate(Event event, LocalDateTime occurrenceDate, RecurrenceUpdateScope scope) {
+    public void validateUpdate(
+            Event event,
+            RecurrenceGroupReqDTO.UpdateReq req,
+            LocalDateTime occurrenceDate,
+            RecurrenceUpdateScope scope
+    ) {
         validateOccurrenceDate(event, occurrenceDate);
-        validateScope(event, occurrenceDate, scope);
+        validateScope(event, req, occurrenceDate, scope);
     }
 
     public void validateDelete(
@@ -32,7 +38,7 @@ public class EventValidator {
             RecurrenceUpdateScope scope
     ) {
         validateOccurrenceDate(event, occurrenceDate);
-        validateScope(event, occurrenceDate, scope);
+        validateScope(event, null, occurrenceDate, scope);
     }
 
     public void validateTime(LocalDateTime start, LocalDateTime end) {
@@ -68,6 +74,7 @@ public class EventValidator {
 
     private void validateScope(
             Event event,
+            RecurrenceGroupReqDTO.UpdateReq req,
             LocalDateTime occurrenceDate,
             RecurrenceUpdateScope scope
     ) {
@@ -80,6 +87,11 @@ public class EventValidator {
         // 반복 일정에 대한 삭제인데 범위 지정 안한 경우
         if (isRecurring && occurrenceDate != null && scope == null) {
             throw new EventException(EventErrorCode.UPDATE_SCOPE_REQUIRED);
+        }
+
+        // 반복 일정에 특정 날짜를 기준으로 반복 필드를 수정할 때, THIS_AND_FOLLOWING_EVENTS가 아닌경우
+        if (req != null && scope != RecurrenceUpdateScope.THIS_AND_FOLLOWING_EVENTS) {
+            throw new EventException(EventErrorCode.THIS_AND_FOLLOWING_EVENTS_ONLY);
         }
     }
 

--- a/src/main/java/com/project/backend/domain/event/validator/EventValidator.java
+++ b/src/main/java/com/project/backend/domain/event/validator/EventValidator.java
@@ -8,7 +8,6 @@ import com.project.backend.domain.event.exception.EventErrorCode;
 import com.project.backend.domain.event.exception.EventException;
 import org.springframework.stereotype.Component;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 // TODO static으로 바꾸기
 @Component

--- a/src/main/java/com/project/backend/domain/event/validator/RecurrenceGroupValidator.java
+++ b/src/main/java/com/project/backend/domain/event/validator/RecurrenceGroupValidator.java
@@ -3,7 +3,7 @@ package com.project.backend.domain.event.validator;
 import com.project.backend.domain.event.dto.request.RecurrenceGroupReqDTO;
 import com.project.backend.domain.event.entity.RecurrenceGroup;
 import com.project.backend.domain.event.enums.MonthlyType;
-import com.project.backend.domain.event.enums.MonthlyWeekdayRule;
+import com.project.backend.domain.common.plan.enums.MonthlyWeekdayRule;
 import com.project.backend.domain.event.enums.RecurrenceEndType;
 import com.project.backend.domain.event.enums.RecurrenceFrequency;
 import com.project.backend.domain.event.exception.RecurrenceGroupErrorCode;

--- a/src/main/java/com/project/backend/domain/todo/controller/TodoDocs.java
+++ b/src/main/java/com/project/backend/domain/todo/controller/TodoDocs.java
@@ -96,10 +96,11 @@ public interface TodoDocs {
                 | 필드 | 타입 | 필수 | 설명 |
                 |------|------|------|------|
                 | `weekOfMonth` | Integer | ✅ | 몇 번째 주 (1~5, -1=마지막) |
-                | `dayOfWeekInMonth` | DayOfWeek | ✅ | 요일 |
+                | `weekdayRule` | MonthlyWeekDayRule | ✅ | 단일요일(SINGLE), 평일(WEEKEND), 주말(WEEKEND), 1주 전체(ALL_DAYS)
+                | `dayOfWeekInMonth` | List<DayOfWeek> | ✅ | 요일 |
 
-                예: 매월 두 번째 화요일 → `weekOfMonth: 2`, `dayOfWeekInMonth: "TUESDAY"`
-
+                예: 매월 두 번째 화요일 → `weekOfMonth: 2`, `weekdayRule: "SINGLE"`, `dayOfWeekInMonth: "TUESDAY"` <br>
+                   매월 두 번째 평일 -> `weekOfMonth: 2`, `weekdayRule: "WEEKDAY"`, `dayOfWeekInMonth: null`
                 ---
                 ## 📅 연간 반복 (YEARLY)
 
@@ -209,6 +210,7 @@ public interface TodoDocs {
                                                 "intervalValue": 1,
                                                 "monthlyType": "DAY_OF_WEEK",
                                                 "weekOfMonth": 2,
+                                                "weekDayRule": "SINGLE",
                                                 "dayOfWeekInMonth": "TUESDAY",
                                                 "endType": "END_BY_COUNT",
                                                 "occurrenceCount": 12

--- a/src/main/java/com/project/backend/domain/todo/converter/TodoConverter.java
+++ b/src/main/java/com/project/backend/domain/todo/converter/TodoConverter.java
@@ -238,8 +238,8 @@ public class TodoConverter {
                 : null;
 
         // "MONDAY" → DayOfWeek
-        DayOfWeek dayOfWeekInMonth = group.getDayOfWeekInMonth() != null
-                ? DayOfWeek.valueOf(group.getDayOfWeekInMonth())
+        List<DayOfWeek> dayOfWeekInMonth = group.getDayOfWeekInMonth() != null
+                ? RecurrenceUtils.parseDaysOfWeek(group.getDayOfWeekInMonth())
                 : null;
 
         return TodoResDTO.RecurrenceGroupRes.builder()

--- a/src/main/java/com/project/backend/domain/todo/converter/TodoConverter.java
+++ b/src/main/java/com/project/backend/domain/todo/converter/TodoConverter.java
@@ -1,5 +1,6 @@
 package com.project.backend.domain.todo.converter;
 
+import com.project.backend.domain.common.plan.enums.MonthlyWeekdayRule;
 import com.project.backend.domain.member.entity.Member;
 import com.project.backend.domain.todo.dto.request.TodoReqDTO;
 import com.project.backend.domain.todo.dto.response.TodoResDTO;

--- a/src/main/java/com/project/backend/domain/todo/converter/TodoConverter.java
+++ b/src/main/java/com/project/backend/domain/todo/converter/TodoConverter.java
@@ -62,10 +62,15 @@ public class TodoConverter {
                         .collect(Collectors.joining(","))
                 : null;
 
+        // SINGLE이 아닌데, dayOfWeekInMonth 입력 시 예외처리
+        if (reqDTO.dayOfWeekInMonth() == null && reqDTO.weekdayRule() != MonthlyWeekdayRule.SINGLE) {
+            throw new IllegalArgumentException("dayOfWeekInMonth must be null when weekdayRule is not SINGLE.");
+        }
+
         // DayOfWeek → "MONDAY" 형태로 변환
         String dayOfWeekInMonth = reqDTO.dayOfWeekInMonth() != null
                 ? reqDTO.dayOfWeekInMonth().name()
-                : null;
+                : RecurrenceUtils.normalizeDayOfWeekInMonth(reqDTO.weekdayRule());
 
         return TodoRecurrenceGroup.create(
                 member,
@@ -242,6 +247,9 @@ public class TodoConverter {
                 ? RecurrenceUtils.parseDaysOfWeek(group.getDayOfWeekInMonth())
                 : null;
 
+        // "MONDAY,WEDNESDAY" → List<DayOfWeek>
+        MonthlyWeekdayRule weekdayRule = RecurrenceUtils.inferWeekdayRule(dayOfWeekInMonth);
+
         return TodoResDTO.RecurrenceGroupRes.builder()
                 .frequency(group.getFrequency())
                 .intervalValue(group.getIntervalValue())
@@ -249,6 +257,7 @@ public class TodoConverter {
                 .monthlyType(group.getMonthlyType())
                 .daysOfMonth(daysOfMonth)
                 .weekOfMonth(group.getWeekOfMonth())
+                .weekdayRule(weekdayRule)
                 .dayOfWeekInMonth(dayOfWeekInMonth)
                 .endType(group.getEndType())
                 .endDate(group.getEndDate())

--- a/src/main/java/com/project/backend/domain/todo/dto/request/TodoReqDTO.java
+++ b/src/main/java/com/project/backend/domain/todo/dto/request/TodoReqDTO.java
@@ -1,6 +1,7 @@
 package com.project.backend.domain.todo.dto.request;
 
 import com.project.backend.domain.event.enums.MonthlyType;
+import com.project.backend.domain.common.plan.enums.MonthlyWeekdayRule;
 import com.project.backend.domain.event.enums.RecurrenceEndType;
 import com.project.backend.domain.event.enums.RecurrenceFrequency;
 import com.project.backend.domain.todo.enums.Priority;
@@ -60,6 +61,8 @@ public class TodoReqDTO {
             List<Integer> daysOfMonth,
 
             Integer weekOfMonth,
+
+            MonthlyWeekdayRule weekdayRule,
 
             DayOfWeek dayOfWeekInMonth,
 

--- a/src/main/java/com/project/backend/domain/todo/dto/response/TodoResDTO.java
+++ b/src/main/java/com/project/backend/domain/todo/dto/response/TodoResDTO.java
@@ -90,6 +90,7 @@ public class TodoResDTO {
             List<Integer> daysOfMonth,
             Integer weekOfMonth,
             DayOfWeek dayOfWeekInMonth,
+            List<DayOfWeek> dayOfWeekInMonth,
             RecurrenceEndType endType,
             LocalDate endDate,
             Integer occurrenceCount

--- a/src/main/java/com/project/backend/domain/todo/dto/response/TodoResDTO.java
+++ b/src/main/java/com/project/backend/domain/todo/dto/response/TodoResDTO.java
@@ -1,5 +1,6 @@
 package com.project.backend.domain.todo.dto.response;
 
+import com.project.backend.domain.common.plan.enums.MonthlyWeekdayRule;
 import com.project.backend.domain.event.enums.MonthlyType;
 import com.project.backend.domain.event.enums.RecurrenceEndType;
 import com.project.backend.domain.event.enums.RecurrenceFrequency;
@@ -89,7 +90,7 @@ public class TodoResDTO {
             MonthlyType monthlyType,
             List<Integer> daysOfMonth,
             Integer weekOfMonth,
-            DayOfWeek dayOfWeekInMonth,
+            MonthlyWeekdayRule weekdayRule,
             List<DayOfWeek> dayOfWeekInMonth,
             RecurrenceEndType endType,
             LocalDate endDate,

--- a/src/main/java/com/project/backend/domain/todo/entity/TodoRecurrenceGroup.java
+++ b/src/main/java/com/project/backend/domain/todo/entity/TodoRecurrenceGroup.java
@@ -50,7 +50,7 @@ public class TodoRecurrenceGroup extends BaseEntity implements RecurrenceRule {
     private Integer weekOfMonth;
 
     // MONTHLY (DAY_OF_WEEK): 반복 요일 (예: "MONDAY")
-    @Column(name = "day_of_week_in_month", length = 20)
+    @Column(name = "day_of_week_in_month", length = 60)
     private String dayOfWeekInMonth;
 
     // 종료 조건

--- a/src/main/java/com/project/backend/domain/todo/entity/TodoRecurrenceGroup.java
+++ b/src/main/java/com/project/backend/domain/todo/entity/TodoRecurrenceGroup.java
@@ -1,7 +1,6 @@
 package com.project.backend.domain.todo.entity;
 
 import com.project.backend.domain.event.enums.MonthlyType;
-import com.project.backend.domain.event.enums.MonthlyWeekdayRule;
 import com.project.backend.domain.event.enums.RecurrenceEndType;
 import com.project.backend.domain.event.enums.RecurrenceFrequency;
 import com.project.backend.domain.member.entity.Member;

--- a/src/main/java/com/project/backend/global/recurrence/RecurrenceRule.java
+++ b/src/main/java/com/project/backend/global/recurrence/RecurrenceRule.java
@@ -1,7 +1,6 @@
 package com.project.backend.global.recurrence;
 
 import com.project.backend.domain.event.enums.MonthlyType;
-import com.project.backend.domain.event.enums.MonthlyWeekdayRule;
 import com.project.backend.domain.event.enums.RecurrenceEndType;
 import com.project.backend.domain.event.enums.RecurrenceFrequency;
 

--- a/src/main/java/com/project/backend/global/recurrence/RecurrenceRule.java
+++ b/src/main/java/com/project/backend/global/recurrence/RecurrenceRule.java
@@ -43,6 +43,11 @@ public interface RecurrenceRule {
      */
     Integer getWeekOfMonth();
 
+//    /**
+//     * 매달 n번째 주, n요일 반복 기준 - SINGLE, WEEKDAY, WEEKEND, ALL_DAYS
+//     */
+//    MonthlyWeekdayRule getWeekdayRule();
+
     /**
      * MONTHLY 반복 (DAY_OF_WEEK): 반복 요일 (예: "MONDAY")
      */

--- a/src/main/java/com/project/backend/global/recurrence/util/RecurrenceUtils.java
+++ b/src/main/java/com/project/backend/global/recurrence/util/RecurrenceUtils.java
@@ -1,5 +1,6 @@
 package com.project.backend.global.recurrence.util;
 
+import com.project.backend.domain.common.plan.enums.MonthlyWeekdayRule;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 

--- a/src/main/java/com/project/backend/global/recurrence/util/RecurrenceUtils.java
+++ b/src/main/java/com/project/backend/global/recurrence/util/RecurrenceUtils.java
@@ -6,7 +6,6 @@ import lombok.NoArgsConstructor;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.YearMonth;
-import java.time.temporal.TemporalAdjusters;
 import java.util.*;
 import java.util.stream.Collectors;
 

--- a/src/main/java/com/project/backend/global/recurrence/util/RecurrenceUtils.java
+++ b/src/main/java/com/project/backend/global/recurrence/util/RecurrenceUtils.java
@@ -126,39 +126,36 @@ public class RecurrenceUtils {
      *    → Optional.empty() (5주차 자체가 없음)
      *
      * @param month       대상 연-월
-     * @param weekOfMonth 주차 (1부터 시작)
+     * @param ordinal 번째 (1부터 시작)
      * @param targetDays  허용된 요일 목록
      * @return 조건을 만족하는 날짜 (없으면 Optional.empty())
      */
-    public static Optional<LocalDate> calculateMonthlyNthWeekday(
+    public static Optional<LocalDate> calculateMonthlyNthOrdinalWeekday(
             YearMonth month,
-            int weekOfMonth,
-            List<DayOfWeek> targetDays
+            int ordinal,                 // 1~5
+            List<DayOfWeek> targetDays   // 허용 요일 집합(단일/주중/주말/전체/다중선택)
     ) {
-        // 해당 달의 1일
-        LocalDate firstDayOfMonth = month.atDay(1);
-
-        // 1주차 시작 = 그 주의 월요일 (ISO)
-        LocalDate startOfFirstWeek =
-                firstDayOfMonth.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));
-
-        // n주차 시작
-        LocalDate startOfTargetWeek =
-                startOfFirstWeek.plusWeeks(weekOfMonth - 1);
-
-        LocalDate endOfTargetWeek = startOfTargetWeek.plusDays(6);
-
-        // 그 주 안에서 target 요일 찾기 (단, 반드시 해당 월에 속해야 함)
-        for (LocalDate d = startOfTargetWeek;
-             !d.isAfter(endOfTargetWeek);
-             d = d.plusDays(1)) {
-
-            if (d.getMonth() == month.getMonth()
-                    && targetDays.contains(d.getDayOfWeek())) {
-                return Optional.of(d);
-            }
+        if (ordinal < 1) {
+            throw new IllegalArgumentException("ordinal must be >= 1");
+        }
+        if (targetDays == null || targetDays.isEmpty()) {
+            return Optional.empty();
         }
 
-        return Optional.empty();
+        int count = 0;
+        LocalDate d = month.atDay(1);
+        LocalDate end = month.atEndOfMonth();
+
+        while (!d.isAfter(end)) {
+            if (targetDays.contains(d.getDayOfWeek())) {
+                count++;
+                if (count == ordinal) {
+                    return Optional.of(d);
+                }
+            }
+            d = d.plusDays(1);
+        }
+
+        return Optional.empty(); // 그 달에는 ordinal번째가 없음
     }
 }


### PR DESCRIPTION
# ☝️Issue Number

Close #89 

##  📌 개요
65eaa1cccef8b7b1b7f130339f0d8742c3d4f6a3
- 반복 일정 수정시, 반복 필드를 수정하는 경우 **THIS_AND_FOLLOWING_EVENTS**만 선택 가능하도록 validator설정

c1b8a1b08e4d49ec2f5425df9bd90c7bf5cbde85 
- n번째 주가 아닌, n번째(ordinal) 기준으로 처리하도록 설정 (`weekOfMonth`가 3이고 `weekDayRule` : **WEEKDAY** 일 경우 해당 달의 3번째 평일로 계산된다.)

ab4b2e2241da5c299bc98d052f253c6d0ac986c8
- common 디렉토리에 있던 파일 위치 정리
  
8cfb65bda8962080e15515d1377ee0d2b8ff8acb
- TODO_반복그룹 반환시, `dayOfWeekInMonth` 타입 `DayOfWeek` -> List<`DayOfWeek`> , 필드 length 20 -> 60

8c0eebe9cd807b1733b666812c62b0daabca1403
- ReqDTO, ResDTO에 `weekdayRule` 변수 추가 및 weekdayRule에 따른 `dayOfWeekInMonth` 변수 추론 메서드 추가

e2ca73db2fa0d2ab9a3489b23c304007c0c57f82
`weekdayRule` 컬럼 제거 및 월간 요일 규칙 파생 처리로 변경
- `RecurrenceGroup`.`weekdayRule` DB 컬럼 삭제
- `dayOfWeekInMonth` 기반으로 `MonthlyWeekdayRule` 추론하도록 변경
- 월간 **DAY_OF_WEEK** 수정 로직 변경
- **SINGLE** 정책에 맞게 validation 및 변경 감지 로직 수정

e06aa89e0f3e5296862f62f88aba675a32e3b41a
- 단일 일정 startTime 변경 시, db에 미적용 문제 해결
 
## 🔁 변경 사항
c1b8a1b08e4d49ec2f5425df9bd90c7bf5cbde85 
- 기존 방식은 weekDayRule을 통해 해당 주차를 파악하는 방식이었는데, 이를 n번째 기준으로 변경해서 애플 캘린더 처럼 평일에 대한 계산이어도 3주차 평일이 아닌, 3번째 평일로 결과가 나오게 로직 리팩토링 진행했습니다. (ex 2월 기준 3번째 평일이면 occurrenceDate는 2026년 2월 4일)

8cfb65bda8962080e15515d1377ee0d2b8ff8acb
- 기존 방식과 다르게 사용자가 평일로 입력하면, 평일이면 월~금을 받기에 length도 늘리고, List로 받도록 변경했습니다.

e2ca73db2fa0d2ab9a3489b23c304007c0c57f82
- db에 `weekDayRule`을 저장하지 않고 입력시에는 해당 필드로 `dayOfWeekInMonth` 필드를 채워넣고, 반환할때는 db에 저장된 `dayOfWeekInMonth`를 통해 `weekDayRule`을 추론해서 반환하도록 리팩토링했습니다.

**일정 생성, 수정시 weekDayRule 사용법**
단일 요일
1. 단일 요일 선택시에는 `weekDayRule` = SINGLE, `dayOfWeekInMonth` = "MONDAY" 입니다.
2.  `weekDayRule` = SINGLE만 보내면, `dayOfweekINMonth` 값은 해당 일정의 startTime의 요일로 초기화됩니다.
3.  `dayOfWeekInMonth` = "MONDAY"만 보내면, `weekDayRule` 값은 무조건 SINGLE로 초기화됩니다.
평일, 주말, 1주 전체
1. `weekDayRule` = "WEEKDAY or WEEKEND or ALL_DAYS" 이면 `dayOfWeekInMonth` = null 입니다.
## 📸 스크린샷

## 👀 기타 더 이야기해볼 점
이제 자연어로 일정 할일 생성 시, 리마인더 생성 처리와, weekDayRule이 적용될 수 있도록 프롬프트 수정 및 로직 개발 작업을 해보겠습니다. 