### PR TITLE
Fix/#98: 선제적 제안 스케줄러 batch process에서 트랜잭션 범위가 올바르지 않았던 이슈

### DIFF
--- a/src/main/java/com/project/backend/domain/nlp/service/NlpSaverService.java
+++ b/src/main/java/com/project/backend/domain/nlp/service/NlpSaverService.java
@@ -1,5 +1,6 @@
 package com.project.backend.domain.nlp.service;
 
+import com.project.backend.domain.common.reminder.bridge.ReminderEventBridge;
 import com.project.backend.domain.event.entity.Event;
 import com.project.backend.domain.event.entity.RecurrenceGroup;
 import com.project.backend.domain.event.enums.RecurrenceEndType;
@@ -10,6 +11,8 @@ import com.project.backend.domain.member.entity.Member;
 import com.project.backend.domain.nlp.dto.request.NlpReqDTO;
 import com.project.backend.domain.nlp.exception.NlpErrorCode;
 import com.project.backend.domain.nlp.exception.NlpException;
+import com.project.backend.domain.reminder.enums.ChangeType;
+import com.project.backend.domain.reminder.enums.TargetType;
 import com.project.backend.domain.todo.entity.Todo;
 import com.project.backend.domain.todo.entity.TodoRecurrenceGroup;
 import com.project.backend.domain.todo.repository.TodoRecurrenceGroupRepository;
@@ -33,6 +36,7 @@ public class NlpSaverService {
     private final RecurrenceGroupRepository recurrenceGroupRepository;
     private final TodoRepository todoRepository;
     private final TodoRecurrenceGroupRepository todoRecurrenceGroupRepository;
+    private final ReminderEventBridge reminderEventBridge;
 
     /**
      * 파싱된 항목을 저장하고 생성된 ID를 반환한다.
@@ -72,6 +76,17 @@ public class NlpSaverService {
         );
 
         eventRepository.save(event);
+
+        // 이벤트 생성에 따른 리스너 생성 로직 실행
+        reminderEventBridge.handlePlanChanged(
+                event.getId(),
+                TargetType.EVENT,
+                member.getId(),
+                event.getTitle(),
+                false,
+                event.getStartTime(),
+                ChangeType.CREATED
+        );
         return event.getId();
     }
 
@@ -106,6 +121,17 @@ public class NlpSaverService {
         group.setEvent(event);
 
         log.debug("반복 일정 생성 완료 - eventId: {}, groupId: {}", event.getId(), group.getId());
+
+        // 이벤트 생성에 따른 리스너 생성 로직 실행
+        reminderEventBridge.handlePlanChanged(
+                event.getId(),
+                TargetType.EVENT,
+                member.getId(),
+                event.getTitle(),
+                true,
+                event.getStartTime(),
+                ChangeType.CREATED
+        );
         return event.getId();
     }
 
@@ -156,6 +182,17 @@ public class NlpSaverService {
         );
 
         todoRepository.save(todo);
+
+        // 투두 생성에 따른 리스너 생성 로직 실행
+        reminderEventBridge.handlePlanChanged(
+                todo.getId(),
+                TargetType.TODO,
+                member.getId(),
+                todo.getTitle(),
+                false,
+                todo.getStartDate().atTime(todo.getDueTime()),
+                ChangeType.CREATED
+        );
         return todo.getId();
     }
 
@@ -191,6 +228,19 @@ public class NlpSaverService {
         group.setTodo(todo);
 
         log.debug("반복 할 일 생성 완료 - todoId: {}, groupId: {}", todo.getId(), group.getId());
+
+        log.info("todo.startDate : {}", todo.getStartDate());
+        log.info("todo.getDueTime : {}", todo.getDueTime());
+        // 투두 생성에 따른 리스너 생성 로직 실행
+        reminderEventBridge.handlePlanChanged(
+                todo.getId(),
+                TargetType.TODO,
+                member.getId(),
+                todo.getTitle(),
+                true,
+                todo.getStartDate().atTime(todo.getDueTime()),
+                ChangeType.CREATED
+        );
         return todo.getId();
     }
 

--- a/src/main/java/com/project/backend/domain/reminder/service/command/ReminderCommandServiceImpl.java
+++ b/src/main/java/com/project/backend/domain/reminder/service/command/ReminderCommandServiceImpl.java
@@ -198,8 +198,8 @@ public class ReminderCommandServiceImpl implements ReminderCommandService {
         // 현재보다 해당 일정의 startTime이 이전이라면 리마인더 생성 x
         if (rs.occurrenceTime().isBefore(LocalDateTime.now())) return;
 
-        // 기존 리마인더 삭제
-        deleteReminder(rs.targetId(), rs.targetType(), rs.occurrenceTime());
+        // 기존 단일 일정에 대한 리마인더 삭제
+        reminderRepository.deleteByTargetIdAndTargetType(rs.targetId(), rs.targetType());
 
         saveReminder(rs, memberId, null, ReminderRole.BASE);
     }
@@ -207,6 +207,9 @@ public class ReminderCommandServiceImpl implements ReminderCommandService {
     @Override
     public void updateReminderOfRecurrence(ReminderSource rs, Long memberId, LocalDateTime occurrenceTime) {
         LocalDateTime now = LocalDateTime.now();
+
+        // 기존 단일 일정에 대한 리마인더 삭제
+        reminderRepository.deleteByTargetIdAndTargetType(rs.targetId(), rs.targetType());
 
         // 이미 지난 일정에 반복을 추가할 경우
         if (rs.occurrenceTime().isBefore(now)) {

--- a/src/main/java/com/project/backend/domain/suggestion/scheduler/SuggestionScheduler.java
+++ b/src/main/java/com/project/backend/domain/suggestion/scheduler/SuggestionScheduler.java
@@ -2,6 +2,7 @@ package com.project.backend.domain.suggestion.scheduler;
 
 import com.project.backend.domain.member.repository.MemberRepository;
 import com.project.backend.domain.suggestion.repository.SuggestionRepository;
+import com.project.backend.domain.suggestion.service.batch.SuggestionBatchService;
 import com.project.backend.domain.suggestion.service.command.SuggestionCommandService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -17,8 +18,7 @@ import java.util.List;
 public class SuggestionScheduler {
 
     private final MemberRepository memberRepository;
-    private final SuggestionCommandService suggestionCommandService;
-    private final SuggestionRepository suggestionRepository;
+    private final SuggestionBatchService suggestionBatchService;
 
     @Value("${spring.scheduler.suggestion.enabled}")
     private boolean enabled;
@@ -35,12 +35,7 @@ public class SuggestionScheduler {
 
         for (Long memberId : memberIds) {
             try {
-                log.info("[Suggestion Scheduler] : 개발 단계에 있으므로 모든 제안을 삭제 후 재생성 합니다");
-                suggestionRepository.deleteAllByMemberId(memberId);
-                suggestionCommandService.createEventSuggestion(memberId);
-                suggestionCommandService.createTodoSuggestion(memberId);
-                suggestionCommandService.createRecurrenceSuggestion(memberId);
-                suggestionCommandService.createTodoRecurrenceSuggestion(memberId);
+                suggestionBatchService.regenerateAllForMember(memberId);
             } catch (Exception e) {
                 log.warn("[Suggestion Scheduler] : 실패 | memberId = {} | failed = {}", memberId, e.getMessage());
             }

--- a/src/main/java/com/project/backend/domain/suggestion/service/batch/SuggestionBatchService.java
+++ b/src/main/java/com/project/backend/domain/suggestion/service/batch/SuggestionBatchService.java
@@ -1,0 +1,6 @@
+package com.project.backend.domain.suggestion.service.batch;
+
+public interface SuggestionBatchService {
+
+    void regenerateAllForMember(Long memberId);
+}

--- a/src/main/java/com/project/backend/domain/suggestion/service/batch/SuggestionBatchServiceImpl.java
+++ b/src/main/java/com/project/backend/domain/suggestion/service/batch/SuggestionBatchServiceImpl.java
@@ -1,0 +1,29 @@
+package com.project.backend.domain.suggestion.service.batch;
+import com.project.backend.domain.suggestion.repository.SuggestionRepository;
+import com.project.backend.domain.suggestion.service.command.SuggestionCommandService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class SuggestionBatchServiceImpl implements SuggestionBatchService{
+
+    private final SuggestionCommandService suggestionCommandService;
+    private final SuggestionRepository suggestionRepository;
+
+    @Override
+    public void regenerateAllForMember(Long memberId) {
+        log.info("[Suggestion Scheduler] : 개발 단계에 있으므로 모든 제안을 삭제 후 재생성 합니다 | memberId={}", memberId);
+
+        suggestionRepository.deleteAllByMemberId(memberId);
+
+        suggestionCommandService.createEventSuggestion(memberId);
+        suggestionCommandService.createTodoSuggestion(memberId);
+        suggestionCommandService.createRecurrenceSuggestion(memberId);
+        suggestionCommandService.createTodoRecurrenceSuggestion(memberId);
+    }
+}

--- a/src/main/java/com/project/backend/domain/suggestion/vo/fingerprint/RecurrenceGroupFingerPrint.java
+++ b/src/main/java/com/project/backend/domain/suggestion/vo/fingerprint/RecurrenceGroupFingerPrint.java
@@ -1,7 +1,9 @@
 package com.project.backend.domain.suggestion.vo.fingerprint;
 
+import com.project.backend.domain.common.plan.enums.MonthlyWeekdayRule;
 import com.project.backend.domain.event.entity.RecurrenceGroup;
 import com.project.backend.domain.event.enums.*;
+import com.project.backend.global.recurrence.util.RecurrenceUtils;
 
 import java.time.LocalDate;
 
@@ -27,7 +29,7 @@ public record RecurrenceGroupFingerPrint(
                 rg.getMonthlyType(),
                 rg.getDaysOfMonth(),
                 rg.getWeekOfMonth(),
-                rg.getMonthlyWeekdayRule(),
+                RecurrenceUtils.inferWeekdayRule(RecurrenceUtils.parseDaysOfWeek(rg.getDayOfWeekInMonth())),
                 rg.getDayOfWeekInMonth(),
                 rg.getMonthOfYear(),
                 rg.getEndType(),


### PR DESCRIPTION
# ☝️Issue Number

Close #98

##  📌 개요

- b276a42d64f8b886e836a6575ec0456555e45b44
  - 제안 삭제시 스케줄러 전체에 트랜잭션을 거는 방식 대신에 batchService로 분리하여 각각의 멤버에 대한 트랜잭션을 구성하여 삭제를 진행할 수 있게 하였습니다

## 🔁 변경 사항

## 📸 스크린샷

## 👀 기타 더 이야기해볼 점
