### PR TITLE
♻️refactor: NIP api 월간 반복에서 평일/주말/전체 요일 지원 추가

### DIFF
--- a/src/main/java/com/project/backend/domain/nlp/contorller/NlpDocs.java
+++ b/src/main/java/com/project/backend/domain/nlp/contorller/NlpDocs.java
@@ -113,7 +113,16 @@ public interface NlpDocs {
                                         """
                             ),
                             @ExampleObject(
-                                    name = "6. 반복 일정 (매년)",
+                                    name = "6. 반복 일정 (매월 N번째 평일)",
+                                    summary = "매월 셋째 평일 오후 7시 헬스",
+                                    value = """
+                                        {
+                                            "text": "매월 셋째 평일 오후 7시 헬스"
+                                        }
+                                        """
+                            ),
+                            @ExampleObject(
+                                    name = "7. 반복 일정 (매년)",
                                     summary = "매년 3월 15일 결혼기념일",
                                     value = """
                                         {
@@ -122,7 +131,7 @@ public interface NlpDocs {
                                         """
                             ),
                             @ExampleObject(
-                                    name = "7. 종료 조건 (N회)",
+                                    name = "8. 종료 조건 (N회)",
                                     summary = "PT 10회 등록",
                                     value = """
                                         {
@@ -131,7 +140,7 @@ public interface NlpDocs {
                                         """
                             ),
                             @ExampleObject(
-                                    name = "8. 복수 항목",
+                                    name = "9. 복수 항목",
                                     summary = "내일 치과, 금요일까지 보고서",
                                     value = """
                                         {
@@ -408,6 +417,7 @@ public interface NlpDocs {
                     "frequency": "MONTHLY",
                     "monthlyType": "DAY_OF_WEEK",
                     "weekOfMonth": 3,
+                    "weekdayRule": "SINGLE",
                     "dayOfWeekInMonth": "TUESDAY",
                     "endType": "NEVER"
                 }
@@ -428,6 +438,9 @@ public interface NlpDocs {
 
                 ## 색상 값 (color)
                 `BLUE` (기본값), `GREEN`, `PINK`, `PURPLE`, `GRAY`, `YELLOW`
+                
+                ## weekdayRule
+                `SINGLE`, `WEEKDAY`, `WEEKEND`, `ALL_DAYS`
                 """
     )
     @io.swagger.v3.oas.annotations.parameters.RequestBody(
@@ -542,6 +555,7 @@ public interface NlpDocs {
                                                         "intervalValue": 1,
                                                         "monthlyType": "DAY_OF_WEEK",
                                                         "weekOfMonth": 3,
+                                                        "weekdayRule": "SINGLE",
                                                         "dayOfWeekInMonth": "TUESDAY",
                                                         "endType": "NEVER"
                                                     }
@@ -551,7 +565,35 @@ public interface NlpDocs {
                                         """
                             ),
                             @ExampleObject(
-                                    name = "6. 반복 일정 (매년)",
+                                    name = "6. 반복 일정 (매월 셋째 평일)",
+                                    summary = "헬스 - 매월 셋째 평일",
+                                    value = """
+                                        {
+                                            "items": [
+                                                {
+                                                    "type": "EVENT",
+                                                    "title": "헬스",
+                                                    "date": "2025-01-21",
+                                                    "startTime": "19:00",
+                                                    "endTime": "20:00",
+                                                    "isAllDay": false,
+                                                    "isRecurring": true,
+                                                    "recurrenceRule": {
+                                                        "frequency": "MONTHLY",
+                                                        "intervalValue": 1,
+                                                        "monthlyType": "DAY_OF_WEEK",
+                                                        "weekOfMonth": 3,
+                                                        "weekdayRule": "WEEKDAY",
+                                                        "dayOfWeekInMonth": "MONDAY,TUESDAY,WEDNESDAY,THURSDAY,FRIDAY",
+                                                        "endType": "NEVER"
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                        """
+                            ),
+                            @ExampleObject(
+                                    name = "7. 반복 일정 (매년)",
                                     summary = "결혼기념일 - 매년 3월 15일",
                                     value = """
                                         {
@@ -576,7 +618,7 @@ public interface NlpDocs {
                                         """
                             ),
                             @ExampleObject(
-                                    name = "7. 종료 조건 (N회 반복)",
+                                    name = "8. 종료 조건 (N회 반복)",
                                     summary = "PT 10회",
                                     value = """
                                         {
@@ -602,7 +644,7 @@ public interface NlpDocs {
                                         """
                             ),
                             @ExampleObject(
-                                    name = "8. 종료 조건 (특정 날짜까지)",
+                                    name = "9. 종료 조건 (특정 날짜까지)",
                                     summary = "스터디 - 6월까지 매주 토요일",
                                     value = """
                                         {
@@ -629,7 +671,7 @@ public interface NlpDocs {
                                         """
                             ),
                             @ExampleObject(
-                                    name = "9. 복수 항목 저장",
+                                    name = "10. 복수 항목 저장",
                                     summary = "일정 + 할 일 동시 저장",
                                     value = """
                                         {

--- a/src/main/java/com/project/backend/domain/nlp/converter/NlpConverter.java
+++ b/src/main/java/com/project/backend/domain/nlp/converter/NlpConverter.java
@@ -7,6 +7,7 @@ import com.project.backend.domain.nlp.dto.response.LlmResDTO;
 import com.project.backend.domain.nlp.dto.response.NlpResDTO;
 import com.project.backend.domain.nlp.enums.ItemType;
 import com.project.backend.domain.event.enums.RecurrenceFrequency;
+import com.project.backend.global.recurrence.util.RecurrenceUtils;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
@@ -137,6 +138,8 @@ public class NlpConverter {
                 .monthlyType(parseMonthlyType(llmRule.monthlyType()))
                 .daysOfMonth(llmRule.daysOfMonth())
                 .weekOfMonth(llmRule.weekOfMonth())
+                .weekdayRule(RecurrenceUtils.inferWeekdayRule( // dayOfWeekInMonth로 추론
+                        RecurrenceUtils.parseDaysOfWeek(llmRule.dayOfWeekInMonth())))
                 .dayOfWeekInMonth(convertDayOfWeek(llmRule.dayOfWeekInMonth()))
                 .monthOfYear(llmRule.monthOfYear())
                 .endType(parseEndType(llmRule.endType(), llmRule.endDate()))

--- a/src/main/java/com/project/backend/domain/nlp/dto/request/NlpReqDTO.java
+++ b/src/main/java/com/project/backend/domain/nlp/dto/request/NlpReqDTO.java
@@ -1,5 +1,6 @@
 package com.project.backend.domain.nlp.dto.request;
 
+import com.project.backend.domain.common.plan.enums.MonthlyWeekdayRule;
 import com.project.backend.domain.event.enums.EventColor;
 import com.project.backend.domain.event.enums.MonthlyType;
 import com.project.backend.domain.event.enums.RecurrenceEndType;
@@ -82,6 +83,9 @@ public class NlpReqDTO {
 
             // MONTHLY (DAY_OF_WEEK): N번째 주 (1~5, -1은 마지막)
             Integer weekOfMonth,
+
+            // MONTHLY (DAY_OF_WEEK): SINGLE / WEEKDAY / WEEKEND / ALL_DAYS
+            MonthlyWeekdayRule weekdayRule,
 
             // MONTHLY (DAY_OF_WEEK): 반복 요일 "MONDAY"
             String dayOfWeekInMonth,

--- a/src/main/resources/prompts/nlp-system-prompt.txt
+++ b/src/main/resources/prompts/nlp-system-prompt.txt
@@ -113,9 +113,36 @@
 **DAY_OF_WEEK (매월 N번째 X요일)**
 - 필수: weekOfMonth, dayOfWeekInMonth
 - weekOfMonth: 1~5 (1=첫째, 5=다섯째), -1은 마지막
+- 단일 요일(예: 월요일/화요일 등)인 경우
+- dayOfWeekInMonth는 반드시 단일 값 1개만 출력
 - 예시: "매월 첫째 월요일 회의" → monthlyType: "DAY_OF_WEEK", weekOfMonth: 1, dayOfWeekInMonth: "MONDAY"
 - 예시: "매월 마지막 금요일 정산" → monthlyType: "DAY_OF_WEEK", weekOfMonth: -1, dayOfWeekInMonth: "FRIDAY"
 - 예시: "매월 셋째 주 화요일" → monthlyType: "DAY_OF_WEEK", weekOfMonth: 3, dayOfWeekInMonth: "TUESDAY"
+
+- 평일/주중(weekday) 표현인 경우
+- dayOfWeekInMonth를 반드시 "MONDAY,TUESDAY,WEDNESDAY,THURSDAY,FRIDAY" 로 출력
+- 예시: "매월 셋째 평일 7시 헬스"
+  → monthlyType: "DAY_OF_WEEK",
+    weekOfMonth: 3,
+    dayOfWeekInMonth: "MONDAY,TUESDAY,WEDNESDAY,THURSDAY,FRIDAY"
+
+- 주말(weekend) 표현인 경우
+- dayOfWeekInMonth를 반드시 "SATURDAY,SUNDAY" 로 출력
+- 예시: "매월 둘째 주말 정리"
+  → monthlyType: "DAY_OF_WEEK",
+    weekOfMonth: 2,
+    dayOfWeekInMonth: "SATURDAY,SUNDAY"
+
+- 매일/1주 전체(all days) 표현인 경우
+- dayOfWeekInMonth를 반드시 "MONDAY,TUESDAY,WEDNESDAY,THURSDAY,FRIDAY,SATURDAY,SUNDAY" 로 출력
+- 예시: "매월 첫째 주는 매일 물 마시기"
+  → monthlyType: "DAY_OF_WEEK",
+    weekOfMonth: 1,
+    dayOfWeekInMonth: "MONDAY,TUESDAY,WEDNESDAY,THURSDAY,FRIDAY,SATURDAY,SUNDAY"
+
+- 공통 규칙
+- 요일은 반드시 전체 이름(MONDAY...)만 사용
+- 쉼표(,)로만 구분하며 공백을 넣지 않는다
 
 #### YEARLY (매년)
 - 필수 필드: frequency, monthOfYear
@@ -260,6 +287,32 @@
     "daysOfMonth": null,
     "weekOfMonth": 3,
     "dayOfWeekInMonth": "TUESDAY",
+    "monthOfYear": null,
+    "endType": "NEVER",
+    "endDate": null,
+    "occurrenceCount": null
+  },
+  "confidence": 0.9
+}
+
+입력: "매월 셋째 평일 오후 7시 헬스"
+{
+  "type": "EVENT",
+  "title": "헬스",
+  "date": "2025-01-20",
+  "startTime": "19:00",
+  "endTime": null,
+  "durationMinutes": 60,
+  "isAllDay": false,
+  "isRecurring": true,
+  "recurrenceRule": {
+    "frequency": "MONTHLY",
+    "intervalValue": 1,
+    "daysOfWeek": null,
+    "monthlyType": "DAY_OF_WEEK",
+    "daysOfMonth": null,
+    "weekOfMonth": 3,
+    "dayOfWeekInMonth": "MONDAY,TUESDAY,WEDNESDAY,THURSDAY,FRIDAY",
     "monthOfYear": null,
     "endType": "NEVER",
     "endDate": null,


### PR DESCRIPTION
# ☝️Issue Number

Close #101 

##  📌 개요

- NIP api 월간 반복에서 평일/주말/전체 요일 지원 추가
- 사용자가 평일 입력 시, dayOfWeekInMonth에 월,화,수,목,금 으로 값이 초기화되고 NlpReqDTO.RecurrenceRule 에 weekdayRule은 dayOfWeekInMonth 값을 통해 유추해서 weekdayRule을 반환합니다.

## 🔁 변경 사항
-**RecurrenceRule** dto에 `weekdayRule` 필드 추가
- **NlpConverter**.**toRecurrenceRule**에도 `weekdayRule` 추가
- **NlpDocs**에 평일 적용 예시 추가 및, 매월 N번째 N요일 예시에 `weekdayRule` 필드 추가
- 프롬프트에 `weekdayRule` 관련 규칙, 예시 추가
## 📸 스크린샷
<img width="816" height="750" alt="image" src="https://github.com/user-attachments/assets/0efa3532-b0c2-42d7-b427-b891ec8adbc7" />
<img width="559" height="575" alt="image" src="https://github.com/user-attachments/assets/9fc35231-74c6-4ce3-8f86-fbcf66ba79e2" />

## 👀 기타 더 이야기해볼 점
