### PR TITLE
Fix/#110 이벤트 캘린더 조회 시 부모의 수정사항이 반영되지 않던 오류

### DIFF
--- a/src/main/java/com/project/backend/domain/event/service/query/EventQueryServiceImpl.java
+++ b/src/main/java/com/project/backend/domain/event/service/query/EventQueryServiceImpl.java
@@ -335,9 +335,27 @@ public class EventQueryServiceImpl implements EventQueryService {
                 recurrenceExceptions =
                         recurrenceExceptionRepository.findAllByRecurrenceGroupId(event.getRecurrenceGroup().getId());
             }
+            LocalDateTime tempStartTime = event.getStartTime();
+            LocalDateTime tempEndTime = event.getEndTime();
+            boolean isSkip = false;
+            for (RecurrenceException ex : recurrenceExceptions) {
+                // 만약 부모 익셉션이 존재한다면
+                if (ex.getExceptionDate().isEqual(event.getStartTime())) {
+                    if (ex.getExceptionType() == OVERRIDE) {
+                        tempStartTime = ex.getStartTime() != null ? ex.getStartTime() : event.getStartTime();
+                        tempEndTime = ex.getEndTime() != null ? ex.getEndTime() : event.getEndTime();
+                        break;
+                    }
+                    else if (ex.getExceptionType() == SKIP) {
+                        isSkip = true;
+                        break;
+                    }
+                }
+            }
+
             // 부모가 검색 범위에 포함되어 있지 않다면 시간만 추출하고 폐기
-            if (!event.getEndTime().isBefore(startRange) && !event.getStartTime().isAfter(endRange)) {
-                expandedEvents.add(EventConverter.toDetailRes(event));
+            if (!isSkip && !tempStartTime.isBefore(startRange) && !tempEndTime.isAfter(endRange)) {
+                expandedEvents.add(EventConverter.toDetailRes(event, tempStartTime, tempEndTime));
             }
             // 부모 이벤트 포함
             int count = 1;

--- a/src/main/java/com/project/backend/domain/event/service/query/EventQueryServiceImpl.java
+++ b/src/main/java/com/project/backend/domain/event/service/query/EventQueryServiceImpl.java
@@ -337,26 +337,37 @@ public class EventQueryServiceImpl implements EventQueryService {
             }
             LocalDateTime tempStartTime = event.getStartTime();
             LocalDateTime tempEndTime = event.getEndTime();
+            RecurrenceException tempEx = null;
             boolean isSkip = false;
             for (RecurrenceException ex : recurrenceExceptions) {
                 // 만약 부모 익셉션이 존재한다면
                 if (ex.getExceptionDate().isEqual(event.getStartTime())) {
-                    if (ex.getExceptionType() == OVERRIDE) {
-                        tempStartTime = ex.getStartTime() != null ? ex.getStartTime() : event.getStartTime();
-                        tempEndTime = ex.getEndTime() != null ? ex.getEndTime() : event.getEndTime();
-                        break;
-                    }
-                    else if (ex.getExceptionType() == SKIP) {
-                        isSkip = true;
-                        break;
-                    }
+                    log.debug("부모 익셉션 존재");
+                    tempEx = ex;
+                }
+            }
+            if (tempEx != null) {
+                if (tempEx.getExceptionType() == OVERRIDE) {
+                    log.debug("오버라이드 존재");
+                    tempStartTime = tempEx.getStartTime() != null ? tempEx.getStartTime() : event.getStartTime();
+                    tempEndTime = tempEx.getEndTime() != null ? tempEx.getEndTime() : event.getEndTime();
+                }
+                else if (tempEx.getExceptionType() == SKIP) {
+                    log.debug("스킵 존재");
+                    isSkip = true;
+                }
+                // 부모가 검색 범위에 포함되어 있지 않다면 시간만 추출하고 폐기
+                if (!isSkip && !tempStartTime.isBefore(startRange) && !tempEndTime.isAfter(endRange)) {
+                    log.debug("예외 부모가 범위에 포함되었습니다");
+                    expandedEvents.add(EventConverter.toDetailRes(tempEx, event));
+                }
+            } else {
+                if (!tempStartTime.isBefore(startRange) && !tempEndTime.isAfter(endRange)) {
+                    log.debug("원본 부모가 범위에 포함되었습니다");
+                    expandedEvents.add(EventConverter.toDetailRes(event));
                 }
             }
 
-            // 부모가 검색 범위에 포함되어 있지 않다면 시간만 추출하고 폐기
-            if (!isSkip && !tempStartTime.isBefore(startRange) && !tempEndTime.isAfter(endRange)) {
-                expandedEvents.add(EventConverter.toDetailRes(event, tempStartTime, tempEndTime));
-            }
             // 부모 이벤트 포함
             int count = 1;
             // 생성기에 최초로 들어갈 기준 시간


### PR DESCRIPTION
# ☝️Issue Number

Close #110 

##  📌 개요

- df1d37201258b60684cf3263282c56ad1a7d5986
  - 부모가 OVERRIDE 또는 SKIP 되었을 때, 일정 캘린더 조회에서 반영되지 않던 오류 수정

- ddfff315d6267e7477f6ce2f7777617adb329f16
  - 부모의 수정 사항을 시작 시간과 종료 시간만 반영하던 오류 수정

## 🔁 변경 사항

## 📸 스크린샷

### 시작이 1월 27일인 부모 객체
<img width="1043" height="165" alt="image" src="https://github.com/user-attachments/assets/c6d954a7-8e06-4459-8fa4-92ab2d0d51f0" />

### 부모 객체 수정 사항 적용 완료
<img width="474" height="411" alt="image" src="https://github.com/user-attachments/assets/119490be-1823-4540-98df-26802bd31b89" />


## 👀 기타 더 이야기해볼 점
