### PR TITLE
Fix/#109 event update

### DIFF
--- a/src/main/java/com/project/backend/domain/event/converter/RecurrenceGroupConverter.java
+++ b/src/main/java/com/project/backend/domain/event/converter/RecurrenceGroupConverter.java
@@ -142,14 +142,19 @@ public class RecurrenceGroupConverter {
     public static RecurrenceException toRecurrenceExceptionForUpdate(
             EventReqDTO.UpdateReq req,
             RecurrenceGroup recurrenceGroup,
-            LocalDateTime occurrenceDate
+            LocalDateTime occurrenceDate,
+            Integer duration
     ) {
+        LocalDateTime startTime = req.startTime() != null ? req.startTime() : null;
+        LocalDateTime endTime = req.endTime() != null
+                ? req.endTime()
+                : startTime != null ? startTime.plusMinutes(duration) : null;
         return RecurrenceException.builder()
                 .exceptionDate(occurrenceDate)
                 .title(req.title() != null ? req.title() : null)
                 .content(req.content() != null ? req.content() : null)
-                .startTime(req.startTime() != null ? req.startTime() : null)
-                .endTime(req.endTime() != null ? req.endTime() : null)
+                .startTime(startTime)
+                .endTime(endTime)
                 .exceptionType(ExceptionType.OVERRIDE)
                 .location(req.location() != null ? req.location() : null)
                 .color(req.color() != null ? req.color() : null)

--- a/src/main/java/com/project/backend/domain/event/converter/RecurrenceGroupConverter.java
+++ b/src/main/java/com/project/backend/domain/event/converter/RecurrenceGroupConverter.java
@@ -350,13 +350,15 @@ public class RecurrenceGroupConverter {
 
         b.frequency(frequency);
 
-        Integer interval;
+        int interval;
         if (frequency == RecurrenceFrequency.WEEKLY) {
             // WEEKLY는 무조건 1
             interval = 1;
         } else {
             // WEEKLY가 아닌 경우만 req → rg 순으로 선택
-            interval = req.intervalValue() != null ? req.intervalValue() : rg.getIntervalValue();
+            interval = req.intervalValue() != null
+                    ? req.intervalValue()
+                    : rg != null ? rg.getIntervalValue() : 1;
         }
 
         b.interval(interval);

--- a/src/main/java/com/project/backend/domain/event/entity/Event.java
+++ b/src/main/java/com/project/backend/domain/event/entity/Event.java
@@ -161,4 +161,9 @@ public class Event extends BaseEntity {
         this.recurrenceGroup = recurrenceGroup;
         this.recurrenceFrequency = recurrenceGroup.getFrequency();
     }
+
+    public void updateTime(LocalDateTime startTime, LocalDateTime endTime) {
+        this.startTime = startTime;
+        this.endTime = endTime;
+    }
 }

--- a/src/main/java/com/project/backend/domain/event/service/RecurrenceTimeAdjuster.java
+++ b/src/main/java/com/project/backend/domain/event/service/RecurrenceTimeAdjuster.java
@@ -178,27 +178,44 @@ public class RecurrenceTimeAdjuster {
             return base;
         }
 
+        // 이번 달 먼저, 후보가 base보다 이전이면 다음 달로 1번 더 시도
         YearMonth month = YearMonth.from(base);
 
-        // 해당 월의 n번째 주 시작 (월요일 기준)
-        LocalDate startOfNthWeek = getNthWeekday(month, week, DayOfWeek.MONDAY);
-        if (startOfNthWeek == null) {
-            throw new IllegalStateException("Invalid weekOfMonth");
-        }
-
-        LocalDate endOfNthWeek = startOfNthWeek.plusDays(6);
-
-        // 그 주 안에서 rule에 맞는 첫 번째 요일 선택
-        for (LocalDate d = startOfNthWeek;
-             !d.isAfter(endOfNthWeek);
-             d = d.plusDays(1)) {
-
-            if (targetDays.contains(d.getDayOfWeek())) {
-                return LocalDateTime.of(d, base.toLocalTime());
+        LocalDate candidateDate = findNthWeekCandidate(month, week, targetDays);
+        if (candidateDate != null) {
+            LocalDateTime candidate = LocalDateTime.of(candidateDate, base.toLocalTime());
+            if (!candidate.isBefore(base)) {
+                return candidate; // candidate >= base 이면 이번 달 확정
             }
         }
 
+        // 이번 달 후보가 base보다 이전이거나(= 과거), 아예 없으면 다음 달
+        YearMonth nextMonth = month.plusMonths(1);
+        LocalDate nextCandidateDate = findNthWeekCandidate(nextMonth, week, targetDays);
+        if (nextCandidateDate != null) {
+            return LocalDateTime.of(nextCandidateDate, base.toLocalTime());
+        }
+
         throw new RecurrenceGroupException(RecurrenceGroupErrorCode.FAIL_ADJUSTMENT_DAY_OF_WEEK);
+    }
+
+    private static LocalDate findNthWeekCandidate(
+            YearMonth month,
+            int week,
+            List<DayOfWeek> targetDays
+    ) {
+        // 해당 월의 n번째 주 시작(월요일 기준)
+        LocalDate startOfNthWeek = getNthWeekday(month, week, DayOfWeek.MONDAY);
+        if (startOfNthWeek == null) return null;
+
+        LocalDate endOfNthWeek = startOfNthWeek.plusDays(6);
+
+        for (LocalDate d = startOfNthWeek; !d.isAfter(endOfNthWeek); d = d.plusDays(1)) {
+            if (targetDays.contains(d.getDayOfWeek())) {
+                return d; // 그 주 안에서 rule에 맞는 첫 날짜
+            }
+        }
+        return null;
     }
 
     private static LocalDate getNthWeekday(

--- a/src/main/java/com/project/backend/domain/event/service/command/EventCommandServiceImpl.java
+++ b/src/main/java/com/project/backend/domain/event/service/command/EventCommandServiceImpl.java
@@ -466,7 +466,8 @@ public class EventCommandServiceImpl implements EventCommandService {
             return;
         }
 
-        RecurrenceException ex = RecurrenceGroupConverter.toRecurrenceExceptionForUpdate(req, rg, occurrenceDate);
+        RecurrenceException ex = RecurrenceGroupConverter.toRecurrenceExceptionForUpdate(
+                req, rg, occurrenceDate, event.getDurationMinutes());
         recurrenceExRepository.save(ex);
         rg.addExceptionDate(ex); // 해당 event가 속했던 반복 객체에 예외 날짜 추가
 

--- a/src/main/java/com/project/backend/domain/event/service/command/EventCommandServiceImpl.java
+++ b/src/main/java/com/project/backend/domain/event/service/command/EventCommandServiceImpl.java
@@ -161,7 +161,7 @@ public class EventCommandServiceImpl implements EventCommandService {
                 RecurrenceGroupReqDTO.CreateReq createReq =
                         RecurrenceGroupConverter.toCreateReq(req.recurrenceGroup());
                 rgValidator.validateCreate(createReq, start);
-                RecurrenceGroup rg = updateToRecurrenceEvent(req, req.recurrenceGroup(), member, start);
+                RecurrenceGroup rg = updateToRecurrenceEvent(req, req.recurrenceGroup(), event, member, start);
                 event.updateRecurrenceGroup(rg);
                 rg.updateEvent(event);
                 // 이벤트 + 반복 생성에 따른 리스너 수정 로직 실행
@@ -424,9 +424,16 @@ public class EventCommandServiceImpl implements EventCommandService {
     private RecurrenceGroup updateToRecurrenceEvent(
             EventReqDTO.UpdateReq eventReq,
             RecurrenceGroupReqDTO.UpdateReq rgReq,
+            Event event,
             Member member,
             LocalDateTime start) {
         RecurrenceGroupSpec rgSpec = RecurrenceGroupConverter.from(eventReq, rgReq, null, start);
+
+        AdjustedTime adjusted = RecurrenceTimeAdjuster.adjust(event.getStartTime(), event.getEndTime(), rgSpec);
+
+        // 생성된 반복에 따른 일정 start,endTime 업데이트
+        event.updateTime(adjusted.start(), adjusted.end());
+
         return createRecurrenceGroup(rgSpec, member);
     }
 

--- a/src/main/java/com/project/backend/domain/event/service/query/EventQueryServiceImpl.java
+++ b/src/main/java/com/project/backend/domain/event/service/query/EventQueryServiceImpl.java
@@ -335,9 +335,27 @@ public class EventQueryServiceImpl implements EventQueryService {
                 recurrenceExceptions =
                         recurrenceExceptionRepository.findAllByRecurrenceGroupId(event.getRecurrenceGroup().getId());
             }
+            LocalDateTime tempStartTime = event.getStartTime();
+            LocalDateTime tempEndTime = event.getEndTime();
+            boolean isSkip = false;
+            for (RecurrenceException ex : recurrenceExceptions) {
+                // 만약 부모 익셉션이 존재한다면
+                if (ex.getExceptionDate().isEqual(event.getStartTime())) {
+                    if (ex.getExceptionType() == OVERRIDE) {
+                        tempStartTime = ex.getStartTime() != null ? ex.getStartTime() : event.getStartTime();
+                        tempEndTime = ex.getEndTime() != null ? ex.getEndTime() : event.getEndTime();
+                        break;
+                    }
+                    else if (ex.getExceptionType() == SKIP) {
+                        isSkip = true;
+                        break;
+                    }
+                }
+            }
+
             // 부모가 검색 범위에 포함되어 있지 않다면 시간만 추출하고 폐기
-            if (!event.getEndTime().isBefore(startRange) && !event.getStartTime().isAfter(endRange)) {
-                expandedEvents.add(EventConverter.toDetailRes(event));
+            if (!isSkip && !tempStartTime.isBefore(startRange) && !tempEndTime.isAfter(endRange)) {
+                expandedEvents.add(EventConverter.toDetailRes(event, tempStartTime, tempEndTime));
             }
             // 부모 이벤트 포함
             int count = 1;

--- a/src/main/java/com/project/backend/domain/event/service/query/EventQueryServiceImpl.java
+++ b/src/main/java/com/project/backend/domain/event/service/query/EventQueryServiceImpl.java
@@ -337,26 +337,37 @@ public class EventQueryServiceImpl implements EventQueryService {
             }
             LocalDateTime tempStartTime = event.getStartTime();
             LocalDateTime tempEndTime = event.getEndTime();
+            RecurrenceException tempEx = null;
             boolean isSkip = false;
             for (RecurrenceException ex : recurrenceExceptions) {
                 // 만약 부모 익셉션이 존재한다면
                 if (ex.getExceptionDate().isEqual(event.getStartTime())) {
-                    if (ex.getExceptionType() == OVERRIDE) {
-                        tempStartTime = ex.getStartTime() != null ? ex.getStartTime() : event.getStartTime();
-                        tempEndTime = ex.getEndTime() != null ? ex.getEndTime() : event.getEndTime();
-                        break;
-                    }
-                    else if (ex.getExceptionType() == SKIP) {
-                        isSkip = true;
-                        break;
-                    }
+                    log.debug("부모 익셉션 존재");
+                    tempEx = ex;
+                }
+            }
+            if (tempEx != null) {
+                if (tempEx.getExceptionType() == OVERRIDE) {
+                    log.debug("오버라이드 존재");
+                    tempStartTime = tempEx.getStartTime() != null ? tempEx.getStartTime() : event.getStartTime();
+                    tempEndTime = tempEx.getEndTime() != null ? tempEx.getEndTime() : event.getEndTime();
+                }
+                else if (tempEx.getExceptionType() == SKIP) {
+                    log.debug("스킵 존재");
+                    isSkip = true;
+                }
+                // 부모가 검색 범위에 포함되어 있지 않다면 시간만 추출하고 폐기
+                if (!isSkip && !tempStartTime.isBefore(startRange) && !tempEndTime.isAfter(endRange)) {
+                    log.debug("예외 부모가 범위에 포함되었습니다");
+                    expandedEvents.add(EventConverter.toDetailRes(tempEx, event));
+                }
+            } else {
+                if (!tempStartTime.isBefore(startRange) && !tempEndTime.isAfter(endRange)) {
+                    log.debug("원본 부모가 범위에 포함되었습니다");
+                    expandedEvents.add(EventConverter.toDetailRes(event));
                 }
             }
 
-            // 부모가 검색 범위에 포함되어 있지 않다면 시간만 추출하고 폐기
-            if (!isSkip && !tempStartTime.isBefore(startRange) && !tempEndTime.isAfter(endRange)) {
-                expandedEvents.add(EventConverter.toDetailRes(event, tempStartTime, tempEndTime));
-            }
             // 부모 이벤트 포함
             int count = 1;
             // 생성기에 최초로 들어갈 기준 시간

--- a/src/main/java/com/project/backend/domain/event/service/query/EventQueryServiceImpl.java
+++ b/src/main/java/com/project/backend/domain/event/service/query/EventQueryServiceImpl.java
@@ -63,10 +63,10 @@ public class EventQueryServiceImpl implements EventQueryService {
 
         eventValidator.validateRead(event, occurrenceDate);
 
-        // 찾고자 하는 것이 부모 이벤트인 경우
-        if (event.getStartTime().isEqual(occurrenceDate)) {
-            return EventConverter.toDetailRes(event);
-        }
+//        // 찾고자 하는 것이 부모 이벤트인 경우
+//        if (event.getStartTime().isEqual(occurrenceDate)) {
+//            return EventConverter.toDetailRes(event);
+//        }
 
         return eventOccurrenceResolver.resolveForRead(event, occurrenceDate);
     }


### PR DESCRIPTION
# ☝️Issue Number

Close #109 

##  📌 개요
9c84d557b149776684726859080a3507d24bf3f7
- 일정 상세 조회 시, 부모 일정에 대한 반환 시, 수정 사항에 대한 미반영 문제 해결

1e1b5dcc98f248a9fc21c64352a11fa6a70ef574
- THIS_EVENT 수정시, startTime을 수정한 경우, endTime도 duration에 맞게 수정되도록 설정

5112614c4b66c8d44979270bf8d1befa8c473ef1
- 매월 N번째 N요일 수정 시, 원본일정의 startTime이 설정한 n번째 n요일이 현재 월 기준 보다 이전이면 다음 달로 넘기고, 이후면 해당 달로 설정
## 🔁 변경 사항
5112614c4b66c8d44979270bf8d1befa8c473ef1
- 해당 일정의 startTime이 2월 20일
  - 매월 1번째 수요일로 설정하면, 3월 4일로 업데이트
  - 매월 4번째 수요일로 설정하면, 2월 25일로 업데이트 
## 📸 스크린샷

## 👀 기타 더 이야기해볼 점
