### PR TITLE
🐛fix: 선제적 제안 스케줄러 수정 및 기타 사항

### DIFF
--- a/src/main/java/com/project/backend/domain/suggestion/executor/CreateEventExecutor.java
+++ b/src/main/java/com/project/backend/domain/suggestion/executor/CreateEventExecutor.java
@@ -53,8 +53,8 @@ public class CreateEventExecutor implements SuggestionExecutor {
                     nextStart);
 
             if (exist) {
-                System.out.println("이미존재");
-                return;
+                return; // anchor 중에 이미 생성된게 하나라도 있다면 전부 생성하지 않음 (같은 키 객체 생성시 애초에 선제적 제안이 만료됨)
+//                continue; // anchor 중에 이미 생성된 것은 제외하고 나머지만 생성
             }
 
             toSave.add(Event.builder()

--- a/src/main/java/com/project/backend/domain/suggestion/executor/CreateTodoExecutor.java
+++ b/src/main/java/com/project/backend/domain/suggestion/executor/CreateTodoExecutor.java
@@ -49,7 +49,8 @@ public class CreateTodoExecutor implements SuggestionExecutor {
             );
 
             if (exist) {
-                return;
+                return; // anchor 중에 이미 생성된게 하나라도 있다면 전부 생성하지 않음 (같은 키 객체 생성시 애초에 선제적 제안이 만료됨)
+//                continue; // anchor 중에 이미 생성된 것은 제외하고 나머지만 생성
             }
 
             toSave.add(Todo.builder()

--- a/src/main/java/com/project/backend/domain/suggestion/scheduler/SuggestionScheduler.java
+++ b/src/main/java/com/project/backend/domain/suggestion/scheduler/SuggestionScheduler.java
@@ -28,6 +28,7 @@ public class SuggestionScheduler {
 
         if (!enabled) {
             log.warn("선제적 제안 스케줄러가 비활성화 상태입니다");
+            return;
         }
 
         List<Long> memberIds = memberRepository.findActiveMemberIdsWithSuggestionEnabled();


### PR DESCRIPTION
# ☝️Issue Number

Close #113 

##  📌 개요

- 6d8cfd93b1cd7bd695ecc3b18faa7967d63aaaa1
  - 선제적 제안 스케줄러에서 스케줄러 비활성화 시 스케줄러가 정상적으로 종료되지 않았던 문제
<img width="894" height="456" alt="image" src="https://github.com/user-attachments/assets/e117ba4f-20bf-44dd-94a3-e3bf8a06ce69" />


- 1826020f32c3cf6ec636ef5a3da3006af825a1df
  - createExecutor 주석 추가
  - <img width="888" height="510" alt="image" src="https://github.com/user-attachments/assets/dc5bcd1d-8a93-44e0-9e0a-67495c39deb3" />
  - 위와 같은 경우에 현재 플로우상으로 return이 걸릴 경우가 거의 없긴 합니다
  - 현재 선제적 제안은 event -> title + location, todo -> title + memo로 키를 만들어서 생성합니다
  - 예를 들어 사용자가 매주 화, 목 반복하는 일정을 단일 객체로 하나하나 만들어서 선제적 제안이 생성되었다면,
  - 위의 조건문이 실행되기 위해서는 선제적 제안으로 생성될, 그 다음 화 또는 목 객체를 만든 경우입니다
  - 이 경우는 이벤트를 예시로, 동일한 title + location의 객체를 화 또는 목요일로 생성했다는 것이며,
  - 이 때 이미 먼저 존재하는 선제적 제안의 Key와 새롭게 생성한 event의 Key가 동일하기 때문에 SuggestionEventListener가 제안을 만료시킵니다
  - 따라서 해당 조건문은 혹시라도 스케줄러와 객체 생성에서 극한의 race condition에 대한 최후 방어막(?) 정도로 생각하시면 될 것 같습니다
  - 그래도 혹시 나중에 비즈니스 로직에 따른 변경사항이 있을 수 있으니 return와 continue의 경우를 주석으로 남겨놓았습니다

## 🔁 변경 사항

## 📸 스크린샷


## 👀 기타 더 이야기해볼 점

# PR 알람이 오락가락해서 댓글이 달린지 몰랐었네요 ㅠㅠ 죄송합니다