### PR TITLE
Refactor/#148: 백엔드 배포 주소 변경 준비

### DIFF
--- a/src/main/java/com/project/backend/global/config/CorsConfig.java
+++ b/src/main/java/com/project/backend/global/config/CorsConfig.java
@@ -24,7 +24,7 @@ public class CorsConfig implements WebMvcConfigurer {
                 "http://localhost:5174",
                 "http://localhost:8080",
                 "http://52.79.121.109:8080",
-                "https://api.calio.kr",
+                "https://api.calio.co.kr",
                 "https://calio.co.kr"
         ));
         configuration.setAllowCredentials(true);

--- a/src/main/resources/yaml/application-dev.yml
+++ b/src/main/resources/yaml/application-dev.yml
@@ -40,20 +40,20 @@ spring:
         secret: ${NAVER_CLIENT_SECRET}
 
       authorization-uri: https://nid.naver.com/oauth2.0/authorize
-      redirect-uri: https://api.calio.kr/api/v1/auth/naver/callback
+      redirect-uri: https://api.calio.co.kr/api/v1/auth/naver/callback
       token-uri: https://nid.naver.com/oauth2.0/token
       user-info-uri: https://openapi.naver.com/v1/nid/me
 
     google:
       client-id: ${GOOGLE_CLIENT_ID}
       client-secret: ${GOOGLE_CLIENT_SECRET}
-      redirect-uri: https://api.calio.kr/api/v1/auth/google/callback
+      redirect-uri: https://api.calio.co.kr/api/v1/auth/google/callback
       token-uri: https://oauth2.googleapis.com/token
 
     kakao:
       client-id: ${KAKAO_CLIENT_ID}
       client-secret: ${KAKAO_CLIENT_SECRET}
-      redirect-uri: https://api.calio.kr/api/v1/auth/kakao/callback
+      redirect-uri: https://api.calio.co.kr/api/v1/auth/kakao/callback
 
   llm:
     provider: openai


### PR DESCRIPTION
# ☝️Issue Number

Close #148 

##  📌 개요

- c9ebf33533dd89483453b702cbc16aacb1d395de
  - 로그인 콜백 uri를 변경했습니다
  - 각 provider 관리자 분들은 callback uri 수정 부탁드립니다

- dafb64fe52df539bb02e1fc79eadbee2a6c3ed01
  - allowOrigin에서 기존 api.calio.kr을 삭제하고 api.calio.co.kr으로 변경했습니다

## 🔁 변경 사항

## 📸 스크린샷

## 👀 기타 더 이야기해볼 점
### 혹시라도 제가 못 찾은 이사 준비가 있을까요