### PR TITLE
🐛fix: 선제적 제안 수락 시 findForExecute의 recurrence event/todo LAZY 초기화 예외 수정

### DIFF
--- a/src/main/java/com/project/backend/domain/suggestion/repository/SuggestionRepository.java
+++ b/src/main/java/com/project/backend/domain/suggestion/repository/SuggestionRepository.java
@@ -40,8 +40,10 @@ public interface SuggestionRepository extends JpaRepository<Suggestion, Long> {
         select s from Suggestion s
         left join fetch s.previousEvent
         left join fetch s.previousTodo
-        left join fetch s.recurrenceGroup
-        left join fetch s.todoRecurrenceGroup
+        left join fetch s.recurrenceGroup rg
+        left join fetch rg.event
+        left join fetch s.todoRecurrenceGroup trg
+        left join fetch trg.todo
         left join fetch s.primaryAnchorDate
         left join fetch s.secondaryAnchorDate
         where s.id = :id and s.member.id = :memberId


### PR DESCRIPTION
# ☝️Issue Number

Close #152 

##  📌 개요

- b85a23bec56bafd6c34992b5de53775f3fcc59fb
  - 제안 수락 과정에서 LazyInitializationException이 발생했습니다
  - findForExecute()가 recurrenceGroup, todoRecurrenceGroup만 fetch하고, executor가 실제로 필요로 하는 rg.event, trg.todo는 fetch하지 않았음
  - 벌크 업데이트 이후 영속성 컨텐스트를 clear하면서 executor가 관련 메서드를 호출할 때, event는 초기화 되지 않은 LAZY 프록시 상태이고, 세션이 끊겨서 LazyInitializationException이 발생
  - 따라서 그냥 한방에 다 fetch 해버렸습니다

## 🔁 변경 사항

## 📸 스크린샷

## 👀 기타 더 이야기해볼 점
