### PR TITLE
🐛fix: 선제적 제안 수락 시 영속성 컨텍스트가 비워지면서 변경사항이 적용되지 않았던 오류 수정

### DIFF
--- a/src/main/java/com/project/backend/domain/suggestion/service/command/SuggestionCommandServiceImpl.java
+++ b/src/main/java/com/project/backend/domain/suggestion/service/command/SuggestionCommandServiceImpl.java
@@ -188,6 +188,9 @@ public class SuggestionCommandServiceImpl implements SuggestionCommandService {
         if (updated == 0) {
             throw new SuggestionException(SuggestionErrorCode.SUGGESTION_CONFLICT);
         }
+        // acceptAtomically로 bulkUpdate를 하면서 영속성 컨텍스트가 비워졌기 때문에 해당 제안 객체를 수정하기 위해 다시 엔티티를 올림
+        suggestion = suggestionRepository.findForExecute(suggestionId, memberId)
+                .orElseThrow(() -> new SuggestionException(SuggestionErrorCode.SUGGESTION_NOT_FOUND));
 
         SuggestionExecutor executor = suggestionExecutorFactory.getExecutor(suggestion.getSuggestionType());
 


### PR DESCRIPTION
# ☝️Issue Number

Close #155 

##  📌 개요

- eda185b78878c938eb5025ae0ca73a6b430675f4
  - 선제적 제안이 여러번 수행되는 것을 막고자 bulk update로 동시성 문제를 해결했었음
  - 그러나 clearAutomatically = true 옵션 때문에 update를 수행하고 바로 영속성 컨텍스트를 clear
  - update 이후에 executor의 수정 변경 dirty checking이 안됨
  - 따라서 제안을 가져오고 해당 제안의 bulk update 이후 또 다시 제안을 가져오면서 영속성 컨텍스트에 엔티티를 올리고, 변경을 감지하도록 변경함

## 🔁 변경 사항

## 📸 스크린샷

## 👀 기타 더 이야기해볼 점
