### PR TITLE
Feat/#161 친구 API 구현

### DIFF
--- a/src/main/java/com/project/backend/domain/friend/controller/FriendController.java
+++ b/src/main/java/com/project/backend/domain/friend/controller/FriendController.java
@@ -1,16 +1,15 @@
 package com.project.backend.domain.friend.controller;
 
 import com.project.backend.domain.friend.dto.request.FriendReqDTO;
+import com.project.backend.domain.friend.dto.response.FriendResDTO;
 import com.project.backend.domain.friend.service.command.FriendCommandService;
+import com.project.backend.domain.friend.service.query.FriendQueryService;
 import com.project.backend.global.apiPayload.CustomResponse;
 import com.project.backend.global.security.userdetails.CustomUserDetails;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -18,6 +17,15 @@ import org.springframework.web.bind.annotation.RestController;
 public class FriendController {
 
     private final FriendCommandService friendCommandService;
+    private final FriendQueryService friendQueryService;
+
+    @GetMapping("/requests/sent")
+    public CustomResponse<FriendResDTO.FriendRequestListRes> getSentFriendRequest(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails
+    ) {
+        FriendResDTO.FriendRequestListRes resDTO = friendQueryService.getSentFriendRequest(customUserDetails.getId());
+        return CustomResponse.onSuccess("보낸 친구 요청 목록 조회 완료", resDTO);
+    }
 
     @PostMapping("/request")
     public CustomResponse<String> sendRequest(

--- a/src/main/java/com/project/backend/domain/friend/controller/FriendController.java
+++ b/src/main/java/com/project/backend/domain/friend/controller/FriendController.java
@@ -47,9 +47,18 @@ public class FriendController {
     @PostMapping("/reqeusts/{requestId}/accept")
     public CustomResponse<String> acceptFriendRequest(
             @AuthenticationPrincipal CustomUserDetails customUserDetails,
+            @PathVariable("requestId") Long friendRequestId
+    ) {
+        friendCommandService.acceptRequest(customUserDetails.getId(), friendRequestId);
+        return CustomResponse.onSuccess("친구 요청 수락 완료", null);
+    }
+
+    @PostMapping("/requests/{requestId}/reject")
+    public CustomResponse<String> rejectFriendRequest(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails,
             @PathVariable Long requestId
     ) {
-        friendCommandService.acceptRequest(customUserDetails.getId(), requestId);
-        return CustomResponse.onSuccess("친구 요청 수락 완료", null);
+        friendCommandService.rejectRequest(customUserDetails.getId(), requestId);
+        return CustomResponse.onSuccess("친구 요청 거절 완료", null);
     }
 }

--- a/src/main/java/com/project/backend/domain/friend/controller/FriendController.java
+++ b/src/main/java/com/project/backend/domain/friend/controller/FriendController.java
@@ -1,0 +1,11 @@
+package com.project.backend.domain.friend.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/friends")
+public class FriendController {
+}

--- a/src/main/java/com/project/backend/domain/friend/controller/FriendController.java
+++ b/src/main/java/com/project/backend/domain/friend/controller/FriendController.java
@@ -27,6 +27,14 @@ public class FriendController {
         return CustomResponse.onSuccess("보낸 친구 요청 목록 조회 완료", resDTO);
     }
 
+    @GetMapping("/requests/received")
+    public CustomResponse<FriendResDTO.FriendRequestListRes> getReceivedFriendRequest(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails
+    ) {
+        FriendResDTO.FriendRequestListRes resDTO = friendQueryService.getReceivedFriendRequest(customUserDetails.getId());
+        return CustomResponse.onSuccess("받은 친구 요청 목록 조회 완료", resDTO);
+    }
+
     @PostMapping("/requests")
     public CustomResponse<String> sendRequest(
             @AuthenticationPrincipal CustomUserDetails customUserDetails,

--- a/src/main/java/com/project/backend/domain/friend/controller/FriendController.java
+++ b/src/main/java/com/project/backend/domain/friend/controller/FriendController.java
@@ -27,7 +27,7 @@ public class FriendController {
         return CustomResponse.onSuccess("보낸 친구 요청 목록 조회 완료", resDTO);
     }
 
-    @PostMapping("/request")
+    @PostMapping("/requests")
     public CustomResponse<String> sendRequest(
             @AuthenticationPrincipal CustomUserDetails customUserDetails,
             @RequestBody @Valid FriendReqDTO.SendRequestReq reqDTO

--- a/src/main/java/com/project/backend/domain/friend/controller/FriendController.java
+++ b/src/main/java/com/project/backend/domain/friend/controller/FriendController.java
@@ -35,6 +35,14 @@ public class FriendController {
         return CustomResponse.onSuccess("받은 친구 요청 목록 조회 완료", resDTO);
     }
 
+    @GetMapping()
+    public CustomResponse<FriendResDTO.FriendListRes> getFriend(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails
+    ) {
+        FriendResDTO.FriendListRes resDTO = friendQueryService.getFriend(customUserDetails.getId());
+        return CustomResponse.onSuccess("친구 목록 조회 완료", resDTO);
+    }
+
     @PostMapping("/requests")
     public CustomResponse<String> sendRequest(
             @AuthenticationPrincipal CustomUserDetails customUserDetails,

--- a/src/main/java/com/project/backend/domain/friend/controller/FriendController.java
+++ b/src/main/java/com/project/backend/domain/friend/controller/FriendController.java
@@ -69,4 +69,13 @@ public class FriendController {
         friendCommandService.rejectRequest(customUserDetails.getId(), requestId);
         return CustomResponse.onSuccess("친구 요청 거절 완료", null);
     }
+
+    @DeleteMapping("/{friendId}")
+    public CustomResponse<String> deleteFriend(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails,
+            @PathVariable Long friendId
+    ) {
+        friendCommandService.deleteFriend(customUserDetails.getId(), friendId);
+        return CustomResponse.onSuccess("친구 삭제 완료", null);
+    }
 }

--- a/src/main/java/com/project/backend/domain/friend/controller/FriendController.java
+++ b/src/main/java/com/project/backend/domain/friend/controller/FriendController.java
@@ -1,6 +1,14 @@
 package com.project.backend.domain.friend.controller;
 
+import com.project.backend.domain.friend.dto.request.FriendReqDTO;
+import com.project.backend.domain.friend.service.command.FriendCommandService;
+import com.project.backend.global.apiPayload.CustomResponse;
+import com.project.backend.global.security.userdetails.CustomUserDetails;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -8,4 +16,15 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/friends")
 public class FriendController {
+
+    private final FriendCommandService friendCommandService;
+
+    @PostMapping("/request")
+    public CustomResponse<String> sendRequest(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails,
+            @RequestBody @Valid FriendReqDTO.SendRequestReq reqDTO
+    ) {
+        friendCommandService.sendRequest(customUserDetails.getId(), reqDTO);
+        return CustomResponse.onSuccess("친구 요청 완료", null);
+    }
 }

--- a/src/main/java/com/project/backend/domain/friend/controller/FriendController.java
+++ b/src/main/java/com/project/backend/domain/friend/controller/FriendController.java
@@ -43,4 +43,13 @@ public class FriendController {
         friendCommandService.sendRequest(customUserDetails.getId(), reqDTO);
         return CustomResponse.onSuccess("친구 요청 완료", null);
     }
+
+    @PostMapping("/reqeusts/{requestId}/accept")
+    public CustomResponse<String> acceptFriendRequest(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails,
+            @PathVariable Long requestId
+    ) {
+        friendCommandService.acceptRequest(customUserDetails.getId(), requestId);
+        return CustomResponse.onSuccess("친구 요청 수락 완료", null);
+    }
 }

--- a/src/main/java/com/project/backend/domain/friend/controller/FriendController.java
+++ b/src/main/java/com/project/backend/domain/friend/controller/FriendController.java
@@ -14,13 +14,13 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/friends")
+@RequestMapping("/api/v1")
 public class FriendController {
 
     private final FriendCommandService friendCommandService;
     private final FriendQueryService friendQueryService;
 
-    @GetMapping("/requests/sent")
+    @GetMapping("/friend-requests/sent")
     public CustomResponse<FriendResDTO.FriendRequestListRes> getSentFriendRequest(
             @AuthenticationPrincipal CustomUserDetails customUserDetails
     ) {
@@ -28,7 +28,7 @@ public class FriendController {
         return CustomResponse.onSuccess("보낸 친구 요청 목록 조회 완료", resDTO);
     }
 
-    @GetMapping("/requests/received")
+    @GetMapping("/friend-requests/received")
     public CustomResponse<FriendResDTO.FriendRequestListRes> getReceivedFriendRequest(
             @AuthenticationPrincipal CustomUserDetails customUserDetails
     ) {
@@ -36,7 +36,7 @@ public class FriendController {
         return CustomResponse.onSuccess("받은 친구 요청 목록 조회 완료", resDTO);
     }
 
-    @GetMapping()
+    @GetMapping("/friends")
     public CustomResponse<FriendResDTO.FriendListRes> getFriend(
             @AuthenticationPrincipal CustomUserDetails customUserDetails
     ) {
@@ -44,7 +44,7 @@ public class FriendController {
         return CustomResponse.onSuccess("친구 목록 조회 완료", resDTO);
     }
 
-    @PostMapping("/requests")
+    @PostMapping("/friend-requests")
     public CustomResponse<String> sendRequest(
             @AuthenticationPrincipal CustomUserDetails customUserDetails,
             @RequestBody @Valid FriendReqDTO.SendRequestReq reqDTO
@@ -53,25 +53,25 @@ public class FriendController {
         return CustomResponse.onSuccess(HttpStatus.CREATED, "친구 요청 완료", null);
     }
 
-    @PostMapping("/reqeusts/{requestId}/accept")
+    @PostMapping("/friend-reqeusts/{friendRequestId}/accept")
     public CustomResponse<String> acceptFriendRequest(
             @AuthenticationPrincipal CustomUserDetails customUserDetails,
-            @PathVariable("requestId") Long friendRequestId
+            @PathVariable Long friendRequestId
     ) {
         friendCommandService.acceptRequest(customUserDetails.getId(), friendRequestId);
         return CustomResponse.onSuccess("친구 요청 수락 완료", null);
     }
 
-    @PostMapping("/requests/{requestId}/reject")
+    @PostMapping("/friend-reqeusts/{friendRequestId}/reject")
     public CustomResponse<String> rejectFriendRequest(
             @AuthenticationPrincipal CustomUserDetails customUserDetails,
-            @PathVariable Long requestId
+            @PathVariable Long friendRequestId
     ) {
-        friendCommandService.rejectRequest(customUserDetails.getId(), requestId);
+        friendCommandService.rejectRequest(customUserDetails.getId(), friendRequestId);
         return CustomResponse.onSuccess("친구 요청 거절 완료", null);
     }
 
-    @DeleteMapping("/{friendId}")
+    @DeleteMapping("/friends/{friendId}")
     public CustomResponse<String> deleteFriend(
             @AuthenticationPrincipal CustomUserDetails customUserDetails,
             @PathVariable Long friendId

--- a/src/main/java/com/project/backend/domain/friend/controller/FriendController.java
+++ b/src/main/java/com/project/backend/domain/friend/controller/FriendController.java
@@ -8,6 +8,7 @@ import com.project.backend.global.apiPayload.CustomResponse;
 import com.project.backend.global.security.userdetails.CustomUserDetails;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -49,7 +50,7 @@ public class FriendController {
             @RequestBody @Valid FriendReqDTO.SendRequestReq reqDTO
     ) {
         friendCommandService.sendRequest(customUserDetails.getId(), reqDTO);
-        return CustomResponse.onSuccess("친구 요청 완료", null);
+        return CustomResponse.onSuccess(HttpStatus.CREATED, "친구 요청 완료", null);
     }
 
     @PostMapping("/reqeusts/{requestId}/accept")
@@ -76,6 +77,6 @@ public class FriendController {
             @PathVariable Long friendId
     ) {
         friendCommandService.deleteFriend(customUserDetails.getId(), friendId);
-        return CustomResponse.onSuccess("친구 삭제 완료", null);
+        return CustomResponse.onSuccess(HttpStatus.NO_CONTENT, "친구 삭제 완료", null);
     }
 }

--- a/src/main/java/com/project/backend/domain/friend/converter/FriendConverter.java
+++ b/src/main/java/com/project/backend/domain/friend/converter/FriendConverter.java
@@ -1,8 +1,11 @@
 package com.project.backend.domain.friend.converter;
 
+import com.project.backend.domain.friend.dto.response.FriendResDTO;
 import com.project.backend.domain.friend.entity.Friend;
 import com.project.backend.domain.member.entity.Member;
 import lombok.NoArgsConstructor;
+
+import java.util.List;
 
 @NoArgsConstructor(access = lombok.AccessLevel.PRIVATE)
 public class FriendConverter {
@@ -11,6 +14,20 @@ public class FriendConverter {
         return Friend.builder()
                 .member(member)
                 .friend(friend)
+                .build();
+    }
+
+    public static FriendResDTO.FriendDetailRes toFriendDetailRes(Friend friend) {
+        return FriendResDTO.FriendDetailRes.builder()
+                .id(friend.getId())
+                .opponentName(friend.getFriend().getNickname())
+                .opponentEmail(friend.getFriend().getEmail())
+                .build();
+    }
+
+    public static FriendResDTO.FriendListRes toFriendList(List<FriendResDTO.FriendDetailRes> friendDetailResList) {
+        return FriendResDTO.FriendListRes.builder()
+                .friendDetailList(friendDetailResList)
                 .build();
     }
 }

--- a/src/main/java/com/project/backend/domain/friend/converter/FriendConverter.java
+++ b/src/main/java/com/project/backend/domain/friend/converter/FriendConverter.java
@@ -1,7 +1,16 @@
 package com.project.backend.domain.friend.converter;
 
+import com.project.backend.domain.friend.entity.Friend;
+import com.project.backend.domain.member.entity.Member;
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = lombok.AccessLevel.PRIVATE)
 public class FriendConverter {
+
+    public static Friend toFriend(Member member, Member friend) {
+        return Friend.builder()
+                .member(member)
+                .friend(friend)
+                .build();
+    }
 }

--- a/src/main/java/com/project/backend/domain/friend/converter/FriendConverter.java
+++ b/src/main/java/com/project/backend/domain/friend/converter/FriendConverter.java
@@ -1,0 +1,7 @@
+package com.project.backend.domain.friend.converter;
+
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = lombok.AccessLevel.PRIVATE)
+public class FriendConverter {
+}

--- a/src/main/java/com/project/backend/domain/friend/converter/FriendConverter.java
+++ b/src/main/java/com/project/backend/domain/friend/converter/FriendConverter.java
@@ -13,15 +13,15 @@ public class FriendConverter {
     public static Friend toFriend(Member member, Member friend) {
         return Friend.builder()
                 .member(member)
-                .friend(friend)
+                .opponent(friend)
                 .build();
     }
 
     public static FriendResDTO.FriendDetailRes toFriendDetailRes(Friend friend) {
         return FriendResDTO.FriendDetailRes.builder()
                 .id(friend.getId())
-                .opponentName(friend.getFriend().getNickname())
-                .opponentEmail(friend.getFriend().getEmail())
+                .opponentName(friend.getOpponent().getNickname())
+                .opponentEmail(friend.getOpponent().getEmail())
                 .build();
     }
 

--- a/src/main/java/com/project/backend/domain/friend/converter/FriendRequestConverter.java
+++ b/src/main/java/com/project/backend/domain/friend/converter/FriendRequestConverter.java
@@ -1,9 +1,12 @@
 package com.project.backend.domain.friend.converter;
 
+import com.project.backend.domain.friend.dto.response.FriendResDTO;
 import com.project.backend.domain.friend.entity.FriendRequest;
 import com.project.backend.domain.friend.enums.FriendRequestStatus;
 import com.project.backend.domain.member.entity.Member;
 import lombok.NoArgsConstructor;
+
+import java.util.List;
 
 @NoArgsConstructor(access = lombok.AccessLevel.PRIVATE)
 public class FriendRequestConverter {
@@ -13,6 +16,26 @@ public class FriendRequestConverter {
                 .sender(sender)
                 .receiver(receiver)
                 .status(FriendRequestStatus.PENDING)
+                .build();
+    }
+
+    public static FriendResDTO.FriendRequestDetailRes toFriendRequestDetailRes(
+            FriendRequest friendRequest,
+            Member sender,
+            Member receiver
+    ) {
+        return FriendResDTO.FriendRequestDetailRes.builder()
+                .id(friendRequest.getId())
+                .senderName(sender.getNickname())
+                .receiverName(receiver.getNickname())
+                .build();
+    }
+
+    public static FriendResDTO.FriendRequestListRes toFriendRequestList(
+            List<FriendResDTO.FriendRequestDetailRes> friendRequestDetailList
+    ) {
+        return FriendResDTO.FriendRequestListRes.builder()
+                .friendRequestDetailList(friendRequestDetailList)
                 .build();
     }
 }

--- a/src/main/java/com/project/backend/domain/friend/converter/FriendRequestConverter.java
+++ b/src/main/java/com/project/backend/domain/friend/converter/FriendRequestConverter.java
@@ -1,0 +1,18 @@
+package com.project.backend.domain.friend.converter;
+
+import com.project.backend.domain.friend.entity.FriendRequest;
+import com.project.backend.domain.friend.enums.FriendRequestStatus;
+import com.project.backend.domain.member.entity.Member;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = lombok.AccessLevel.PRIVATE)
+public class FriendRequestConverter {
+
+    public static FriendRequest toFriendRequest(Member sender, Member receiver) {
+        return FriendRequest.builder()
+                .sender(sender)
+                .receiver(receiver)
+                .status(FriendRequestStatus.PENDING)
+                .build();
+    }
+}

--- a/src/main/java/com/project/backend/domain/friend/converter/FriendRequestConverter.java
+++ b/src/main/java/com/project/backend/domain/friend/converter/FriendRequestConverter.java
@@ -21,13 +21,12 @@ public class FriendRequestConverter {
 
     public static FriendResDTO.FriendRequestDetailRes toFriendRequestDetailRes(
             FriendRequest friendRequest,
-            Member sender,
-            Member receiver
+            Member opponent
     ) {
         return FriendResDTO.FriendRequestDetailRes.builder()
                 .id(friendRequest.getId())
-                .senderName(sender.getNickname())
-                .receiverName(receiver.getNickname())
+                .opponentName(opponent.getNickname())
+                .opponentEmail(opponent.getEmail())
                 .build();
     }
 

--- a/src/main/java/com/project/backend/domain/friend/converter/FriendRequestConverter.java
+++ b/src/main/java/com/project/backend/domain/friend/converter/FriendRequestConverter.java
@@ -2,7 +2,6 @@ package com.project.backend.domain.friend.converter;
 
 import com.project.backend.domain.friend.dto.response.FriendResDTO;
 import com.project.backend.domain.friend.entity.FriendRequest;
-import com.project.backend.domain.friend.enums.FriendRequestStatus;
 import com.project.backend.domain.member.entity.Member;
 import lombok.NoArgsConstructor;
 
@@ -15,7 +14,6 @@ public class FriendRequestConverter {
         return FriendRequest.builder()
                 .sender(sender)
                 .receiver(receiver)
-                .status(FriendRequestStatus.PENDING)
                 .build();
     }
 

--- a/src/main/java/com/project/backend/domain/friend/dto/request/FriendReqDTO.java
+++ b/src/main/java/com/project/backend/domain/friend/dto/request/FriendReqDTO.java
@@ -1,4 +1,14 @@
 package com.project.backend.domain.friend.dto.request;
 
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
 public class FriendReqDTO {
+
+    public record SendRequestReq(
+            @Email
+            @NotBlank
+            String email
+    ) {
+    }
 }

--- a/src/main/java/com/project/backend/domain/friend/dto/request/FriendReqDTO.java
+++ b/src/main/java/com/project/backend/domain/friend/dto/request/FriendReqDTO.java
@@ -1,0 +1,4 @@
+package com.project.backend.domain.friend.dto.request;
+
+public class FriendReqDTO {
+}

--- a/src/main/java/com/project/backend/domain/friend/dto/response/FriendResDTO.java
+++ b/src/main/java/com/project/backend/domain/friend/dto/response/FriendResDTO.java
@@ -1,4 +1,22 @@
 package com.project.backend.domain.friend.dto.response;
 
+import lombok.Builder;
+
+import java.util.List;
+
 public class FriendResDTO {
+
+    @Builder
+    public record FriendRequestDetailRes(
+            Long id,
+            String senderName,
+            String receiverName
+    ) {
+    }
+
+    @Builder
+    public record FriendRequestListRes(
+        List<FriendRequestDetailRes> friendRequestDetailList
+    ) {
+    }
 }

--- a/src/main/java/com/project/backend/domain/friend/dto/response/FriendResDTO.java
+++ b/src/main/java/com/project/backend/domain/friend/dto/response/FriendResDTO.java
@@ -19,4 +19,18 @@ public class FriendResDTO {
         List<FriendRequestDetailRes> friendRequestDetailList
     ) {
     }
+
+    @Builder
+    public record FriendDetailRes(
+            Long id,
+            String opponentName,
+            String opponentEmail
+    ) {
+    }
+
+    @Builder
+    public record FriendListRes(
+            List<FriendDetailRes> friendDetailList
+    ) {
+    }
 }

--- a/src/main/java/com/project/backend/domain/friend/dto/response/FriendResDTO.java
+++ b/src/main/java/com/project/backend/domain/friend/dto/response/FriendResDTO.java
@@ -9,8 +9,8 @@ public class FriendResDTO {
     @Builder
     public record FriendRequestDetailRes(
             Long id,
-            String senderName,
-            String receiverName
+            String opponentName,
+            String opponentEmail
     ) {
     }
 

--- a/src/main/java/com/project/backend/domain/friend/dto/response/FriendResDTO.java
+++ b/src/main/java/com/project/backend/domain/friend/dto/response/FriendResDTO.java
@@ -1,0 +1,4 @@
+package com.project.backend.domain.friend.dto.response;
+
+public class FriendResDTO {
+}

--- a/src/main/java/com/project/backend/domain/friend/entity/Friend.java
+++ b/src/main/java/com/project/backend/domain/friend/entity/Friend.java
@@ -1,0 +1,14 @@
+package com.project.backend.domain.friend.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.*;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Table(name = "friend")
+public class Friend {
+}

--- a/src/main/java/com/project/backend/domain/friend/entity/Friend.java
+++ b/src/main/java/com/project/backend/domain/friend/entity/Friend.java
@@ -1,7 +1,8 @@
 package com.project.backend.domain.friend.entity;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.Table;
+import com.project.backend.domain.member.entity.Member;
+import com.project.backend.global.entity.BaseEntity;
+import jakarta.persistence.*;
 import lombok.*;
 
 @Entity
@@ -9,6 +10,18 @@ import lombok.*;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-@Table(name = "friend")
-public class Friend {
+@Table(name = "friend",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"member_id", "friend_id"}))
+public class Friend extends BaseEntity {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;      // 나
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "friend_id", nullable = false)
+    private Member friend;      // 내 친구
 }

--- a/src/main/java/com/project/backend/domain/friend/entity/Friend.java
+++ b/src/main/java/com/project/backend/domain/friend/entity/Friend.java
@@ -22,6 +22,6 @@ public class Friend extends BaseEntity {
     private Member member;      // 나
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "friend_id", nullable = false)
-    private Member friend;      // 내 친구
+    @JoinColumn(name = "opponent_id", nullable = false)
+    private Member opponent;      // 내 친구
 }

--- a/src/main/java/com/project/backend/domain/friend/entity/FriendRequest.java
+++ b/src/main/java/com/project/backend/domain/friend/entity/FriendRequest.java
@@ -1,7 +1,9 @@
 package com.project.backend.domain.friend.entity;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.Table;
+import com.project.backend.domain.friend.enums.FriendRequestStatus;
+import com.project.backend.domain.member.entity.Member;
+import com.project.backend.global.entity.BaseEntity;
+import jakarta.persistence.*;
 import lombok.*;
 
 @Entity
@@ -9,6 +11,23 @@ import lombok.*;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-@Table(name = "friend_request")
-public class FriendRequest {
+@Table(name = "friend_request",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"sender_id", "receiver_id"}))
+public class FriendRequest extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "sender_id", nullable = false)
+    private Member sender;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "receiver_id", nullable = false)
+    private Member receiver;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 10)
+    private FriendRequestStatus status;
 }

--- a/src/main/java/com/project/backend/domain/friend/entity/FriendRequest.java
+++ b/src/main/java/com/project/backend/domain/friend/entity/FriendRequest.java
@@ -1,0 +1,14 @@
+package com.project.backend.domain.friend.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.*;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Table(name = "friend_request")
+public class FriendRequest {
+}

--- a/src/main/java/com/project/backend/domain/friend/entity/FriendRequest.java
+++ b/src/main/java/com/project/backend/domain/friend/entity/FriendRequest.java
@@ -1,6 +1,5 @@
 package com.project.backend.domain.friend.entity;
 
-import com.project.backend.domain.friend.enums.FriendRequestStatus;
 import com.project.backend.domain.member.entity.Member;
 import com.project.backend.global.entity.BaseEntity;
 import jakarta.persistence.*;
@@ -26,8 +25,4 @@ public class FriendRequest extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "receiver_id", nullable = false)
     private Member receiver;
-
-    @Enumerated(EnumType.STRING)
-    @Column(nullable = false, length = 10)
-    private FriendRequestStatus status;
 }

--- a/src/main/java/com/project/backend/domain/friend/enums/FriendRequestStatus.java
+++ b/src/main/java/com/project/backend/domain/friend/enums/FriendRequestStatus.java
@@ -1,0 +1,7 @@
+package com.project.backend.domain.friend.enums;
+
+public enum FriendRequestStatus {
+    PENDING,
+    ACCEPTED,
+    REJECTED,
+}

--- a/src/main/java/com/project/backend/domain/friend/enums/FriendRequestStatus.java
+++ b/src/main/java/com/project/backend/domain/friend/enums/FriendRequestStatus.java
@@ -1,7 +1,0 @@
-package com.project.backend.domain.friend.enums;
-
-public enum FriendRequestStatus {
-    PENDING,
-    ACCEPTED,
-    REJECTED,
-}

--- a/src/main/java/com/project/backend/domain/friend/exception/FriendErrorCode.java
+++ b/src/main/java/com/project/backend/domain/friend/exception/FriendErrorCode.java
@@ -9,6 +9,10 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum FriendErrorCode implements BaseErrorCode {
 
+    ALREADY_FRIEND(HttpStatus.CONFLICT, "FRIEND409_1", "이미 친구입니다."),
+    ALREADY_REQUESTED(HttpStatus.CONFLICT, "FRIEND409_2", "이미 친구 요청이 전송되었습니다"),
+    FRIEND_SAVE_CONFLICT(HttpStatus.CONFLICT, "FRIEND409_3", "친구 저장 충돌"),
+    FRIEND_REQUEST_SAVE_CONFLICT(HttpStatus.CONFLICT, "FRIEND409_4", "친구 요청 저장 충돌"),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/project/backend/domain/friend/exception/FriendErrorCode.java
+++ b/src/main/java/com/project/backend/domain/friend/exception/FriendErrorCode.java
@@ -9,6 +9,10 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum FriendErrorCode implements BaseErrorCode {
 
+    FRIEND_REQUEST_FORBIDDEN(HttpStatus.FORBIDDEN, "FRIEND403_1", "해당 친구 요청에 대한 접근 권한이 없습니다"),
+
+    FRIEND_REQUEST_NOT_FOUND(HttpStatus.NOT_FOUND, "FRIEND404_1", "해당 친구 요청을 찾을 수 없습니다"),
+
     ALREADY_FRIEND(HttpStatus.CONFLICT, "FRIEND409_1", "이미 친구입니다."),
     ALREADY_REQUESTED(HttpStatus.CONFLICT, "FRIEND409_2", "이미 친구 요청이 전송되었습니다"),
     FRIEND_SAVE_CONFLICT(HttpStatus.CONFLICT, "FRIEND409_3", "친구 저장 충돌"),

--- a/src/main/java/com/project/backend/domain/friend/exception/FriendErrorCode.java
+++ b/src/main/java/com/project/backend/domain/friend/exception/FriendErrorCode.java
@@ -1,0 +1,17 @@
+package com.project.backend.domain.friend.exception;
+
+import com.project.backend.global.apiPayload.code.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+@Getter
+public enum FriendErrorCode implements BaseErrorCode {
+
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/project/backend/domain/friend/exception/FriendErrorCode.java
+++ b/src/main/java/com/project/backend/domain/friend/exception/FriendErrorCode.java
@@ -10,8 +10,10 @@ import org.springframework.http.HttpStatus;
 public enum FriendErrorCode implements BaseErrorCode {
 
     FRIEND_REQUEST_FORBIDDEN(HttpStatus.FORBIDDEN, "FRIEND403_1", "해당 친구 요청에 대한 접근 권한이 없습니다"),
+    FRIEND_FORBIDDEN(HttpStatus.FORBIDDEN, "FRIEND403_2", "해당 친구에 대한 접근 권한이 없습니다"),
 
     FRIEND_REQUEST_NOT_FOUND(HttpStatus.NOT_FOUND, "FRIEND404_1", "해당 친구 요청을 찾을 수 없습니다"),
+    FRIEND_NOT_FOUND(HttpStatus.NOT_FOUND, "FRIEND404_2", "해당 친구를 찾을 수 없습니다"),
 
     ALREADY_FRIEND(HttpStatus.CONFLICT, "FRIEND409_1", "이미 친구입니다."),
     ALREADY_REQUESTED(HttpStatus.CONFLICT, "FRIEND409_2", "이미 친구 요청이 전송되었습니다"),

--- a/src/main/java/com/project/backend/domain/friend/exception/FriendException.java
+++ b/src/main/java/com/project/backend/domain/friend/exception/FriendException.java
@@ -1,0 +1,9 @@
+package com.project.backend.domain.friend.exception;
+
+import com.project.backend.global.apiPayload.exception.CustomException;
+
+public class FriendException extends CustomException {
+    public FriendException(FriendErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/project/backend/domain/friend/repository/FriendRepository.java
+++ b/src/main/java/com/project/backend/domain/friend/repository/FriendRepository.java
@@ -5,12 +5,13 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface FriendRepository extends JpaRepository<Friend, Long> {
 
     // memberId, friendId로 친구 객체 찾기
-    boolean existsByMemberIdAndFriendId(Long memberId, Long friendId);
+    boolean existsByMemberIdAndOpponentId(Long memberId, Long friendId);
 
     // memberId로 모든 친구 객체 찬기
     List<Friend> findByMemberId(Long memberId);

--- a/src/main/java/com/project/backend/domain/friend/repository/FriendRepository.java
+++ b/src/main/java/com/project/backend/domain/friend/repository/FriendRepository.java
@@ -4,9 +4,15 @@ import com.project.backend.domain.friend.entity.Friend;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface FriendRepository extends JpaRepository<Friend, Long> {
 
     // memberId, friendId로 친구 객체 찾기
     boolean existsByMemberIdAndFriendId(Long memberId, Long friendId);
+
+    // memberId로 모든 친구 객체 찬기
+    List<Friend> findByMemberId(Long memberId);
+
 }

--- a/src/main/java/com/project/backend/domain/friend/repository/FriendRepository.java
+++ b/src/main/java/com/project/backend/domain/friend/repository/FriendRepository.java
@@ -6,4 +6,7 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface FriendRepository extends JpaRepository<Friend, Long> {
+
+    // memberId, friendId로 친구 객체 찾기
+    boolean existsByMemberIdAndFriendId(Long memberId, Long friendId);
 }

--- a/src/main/java/com/project/backend/domain/friend/repository/FriendRepository.java
+++ b/src/main/java/com/project/backend/domain/friend/repository/FriendRepository.java
@@ -1,0 +1,9 @@
+package com.project.backend.domain.friend.repository;
+
+import com.project.backend.domain.friend.entity.Friend;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface FriendRepository extends JpaRepository<Friend, Long> {
+}

--- a/src/main/java/com/project/backend/domain/friend/repository/FriendRepository.java
+++ b/src/main/java/com/project/backend/domain/friend/repository/FriendRepository.java
@@ -16,4 +16,7 @@ public interface FriendRepository extends JpaRepository<Friend, Long> {
     // memberId로 모든 친구 객체 찬기
     List<Friend> findByMemberId(Long memberId);
 
+    // memberId와 OpponentId로 친구 찾기
+    Optional<Friend> findByMemberIdAndOpponentId(Long memberId, Long friendId);
+
 }

--- a/src/main/java/com/project/backend/domain/friend/repository/FriendRequestRepository.java
+++ b/src/main/java/com/project/backend/domain/friend/repository/FriendRequestRepository.java
@@ -4,6 +4,7 @@ import com.project.backend.domain.friend.entity.FriendRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -14,4 +15,7 @@ public interface FriendRequestRepository extends JpaRepository<FriendRequest, Lo
 
     // 친구 요청 객체 조회
     Optional<FriendRequest> findBySenderIdAndReceiverId(Long memberId, Long friendId);
+
+    // senderId로 객체 조회
+    List<FriendRequest> findBySenderId(Long memberId);
 }

--- a/src/main/java/com/project/backend/domain/friend/repository/FriendRequestRepository.java
+++ b/src/main/java/com/project/backend/domain/friend/repository/FriendRequestRepository.java
@@ -4,6 +4,14 @@ import com.project.backend.domain.friend.entity.FriendRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface FriendRequestRepository extends JpaRepository<FriendRequest, Long> {
+
+    // 친구 요청 존재 여부
+    boolean existsBySenderIdAndReceiverId(Long memberId, Long friendId);
+
+    // 친구 요청 객체 조회
+    Optional<FriendRequest> findBySenderIdAndReceiverId(Long memberId, Long friendId);
 }

--- a/src/main/java/com/project/backend/domain/friend/repository/FriendRequestRepository.java
+++ b/src/main/java/com/project/backend/domain/friend/repository/FriendRequestRepository.java
@@ -18,4 +18,7 @@ public interface FriendRequestRepository extends JpaRepository<FriendRequest, Lo
 
     // senderId로 객체 조회
     List<FriendRequest> findBySenderId(Long memberId);
+
+    // receiverId로 객체 조회
+    List<FriendRequest> findByReceiverId(Long memberId);
 }

--- a/src/main/java/com/project/backend/domain/friend/repository/FriendRequestRepository.java
+++ b/src/main/java/com/project/backend/domain/friend/repository/FriendRequestRepository.java
@@ -1,0 +1,9 @@
+package com.project.backend.domain.friend.repository;
+
+import com.project.backend.domain.friend.entity.FriendRequest;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface FriendRequestRepository extends JpaRepository<FriendRequest, Long> {
+}

--- a/src/main/java/com/project/backend/domain/friend/service/command/FriendCommandService.java
+++ b/src/main/java/com/project/backend/domain/friend/service/command/FriendCommandService.java
@@ -1,4 +1,8 @@
 package com.project.backend.domain.friend.service.command;
 
+import com.project.backend.domain.friend.dto.request.FriendReqDTO;
+
 public interface FriendCommandService {
+
+    void sendRequest(Long memberId, FriendReqDTO.SendRequestReq reqDTO);
 }

--- a/src/main/java/com/project/backend/domain/friend/service/command/FriendCommandService.java
+++ b/src/main/java/com/project/backend/domain/friend/service/command/FriendCommandService.java
@@ -7,4 +7,6 @@ public interface FriendCommandService {
     void sendRequest(Long memberId, FriendReqDTO.SendRequestReq reqDTO);
 
     void acceptRequest(Long memberId, Long friendRequestId);
+
+    void rejectRequest(Long memberId, Long friendRequestId);
 }

--- a/src/main/java/com/project/backend/domain/friend/service/command/FriendCommandService.java
+++ b/src/main/java/com/project/backend/domain/friend/service/command/FriendCommandService.java
@@ -1,0 +1,4 @@
+package com.project.backend.domain.friend.service.command;
+
+public interface FriendCommandService {
+}

--- a/src/main/java/com/project/backend/domain/friend/service/command/FriendCommandService.java
+++ b/src/main/java/com/project/backend/domain/friend/service/command/FriendCommandService.java
@@ -5,4 +5,6 @@ import com.project.backend.domain.friend.dto.request.FriendReqDTO;
 public interface FriendCommandService {
 
     void sendRequest(Long memberId, FriendReqDTO.SendRequestReq reqDTO);
+
+    void acceptRequest(Long memberId, Long friendRequestId);
 }

--- a/src/main/java/com/project/backend/domain/friend/service/command/FriendCommandService.java
+++ b/src/main/java/com/project/backend/domain/friend/service/command/FriendCommandService.java
@@ -9,4 +9,6 @@ public interface FriendCommandService {
     void acceptRequest(Long memberId, Long friendRequestId);
 
     void rejectRequest(Long memberId, Long friendRequestId);
+
+    void deleteFriend(Long memberId, Long friendId);
 }

--- a/src/main/java/com/project/backend/domain/friend/service/command/FriendCommandServiceImpl.java
+++ b/src/main/java/com/project/backend/domain/friend/service/command/FriendCommandServiceImpl.java
@@ -51,19 +51,7 @@ public class FriendCommandServiceImpl implements FriendCommandService{
 
         // 만약 피요청자가 요청자에게 친구 요청을 보냈다면
         if (reversedFriendRequest != null) {
-            // 쌍방향 저장을 위한 친구 객체 생성
-            List<Friend> friendships = List.of(
-                    FriendConverter.toFriend(requester, requestTarget),
-                    FriendConverter.toFriend(requestTarget, requester)
-            );
-            // 저장
-            try {
-                friendRepository.saveAll(friendships);
-            } catch (DataIntegrityViolationException e) {
-                throw new FriendException(FriendErrorCode.FRIEND_SAVE_CONFLICT);
-            }
-            // 저장 완료 후 요청 정보 삭제
-            friendRequestRepository.delete(reversedFriendRequest);
+            saveFriend(reversedFriendRequest);
             return;
         }
 
@@ -76,6 +64,21 @@ public class FriendCommandServiceImpl implements FriendCommandService{
         } catch (DataIntegrityViolationException e) {
             throw new FriendException(FriendErrorCode.FRIEND_REQUEST_SAVE_CONFLICT);
         }
+    }
+
+    @Override
+    public void acceptRequest(Long memberId, Long friendRequestId) {
+
+        // 친구 요청 객체 찾기
+        FriendRequest friendRequest = friendRequestRepository.findById(friendRequestId)
+                .orElseThrow(() -> new FriendException(FriendErrorCode.FRIEND_REQUEST_NOT_FOUND));
+
+        // 해당 친구 요청의 receiver가 세션 자기 자신인지 확인
+        if (!friendRequest.getReceiver().getId().equals(memberId)) {
+            throw new FriendException(FriendErrorCode.FRIEND_REQUEST_FORBIDDEN);
+        }
+
+        saveFriend(friendRequest);
     }
 
     private Member getRequestTarget(Long memberId, String email) {
@@ -96,5 +99,25 @@ public class FriendCommandServiceImpl implements FriendCommandService{
         }
 
         return requestTarget;
+    }
+
+    private void saveFriend(FriendRequest friendRequest) {
+
+        Member sender = friendRequest.getSender();
+        Member receiver = friendRequest.getReceiver();
+
+        // 쌍방향 저장을 위한 친구 객체 생성
+        List<Friend> friendships = List.of(
+                FriendConverter.toFriend(sender, receiver),
+                FriendConverter.toFriend(receiver, sender)
+        );
+        // 저장
+        try {
+            friendRepository.saveAll(friendships);
+        } catch (DataIntegrityViolationException e) {
+            throw new FriendException(FriendErrorCode.FRIEND_SAVE_CONFLICT);
+        }
+        // 저장 완료 후 요청 정보 삭제
+        friendRequestRepository.delete(friendRequest);
     }
 }

--- a/src/main/java/com/project/backend/domain/friend/service/command/FriendCommandServiceImpl.java
+++ b/src/main/java/com/project/backend/domain/friend/service/command/FriendCommandServiceImpl.java
@@ -68,17 +68,19 @@ public class FriendCommandServiceImpl implements FriendCommandService{
 
     @Override
     public void acceptRequest(Long memberId, Long friendRequestId) {
-
         // 친구 요청 객체 찾기
-        FriendRequest friendRequest = friendRequestRepository.findById(friendRequestId)
-                .orElseThrow(() -> new FriendException(FriendErrorCode.FRIEND_REQUEST_NOT_FOUND));
-
-        // 해당 친구 요청의 receiver가 세션 자기 자신인지 확인
-        if (!friendRequest.getReceiver().getId().equals(memberId)) {
-            throw new FriendException(FriendErrorCode.FRIEND_REQUEST_FORBIDDEN);
-        }
-
+        FriendRequest friendRequest = getValidatedFriendRequest(memberId, friendRequestId);
+        // 수락 시 친구 객체 생성
         saveFriend(friendRequest);
+    }
+
+    @Override
+    public void rejectRequest(Long memberId, Long friendRequestId) {
+        // 친구 요청 객체 찾기
+        FriendRequest friendRequest = getValidatedFriendRequest(memberId, friendRequestId);
+
+        // 거절시 완전 삭제
+        friendRequestRepository.delete(friendRequest);
     }
 
     private Member getRequestTarget(Long memberId, String email) {
@@ -119,5 +121,17 @@ public class FriendCommandServiceImpl implements FriendCommandService{
         }
         // 저장 완료 후 요청 정보 삭제
         friendRequestRepository.delete(friendRequest);
+    }
+
+    private FriendRequest getValidatedFriendRequest(Long memberId, Long friendRequestId) {
+        // 친구 요청 객체 찾기
+        FriendRequest friendRequest = friendRequestRepository.findById(friendRequestId)
+                .orElseThrow(() -> new FriendException(FriendErrorCode.FRIEND_REQUEST_NOT_FOUND));
+
+        // 해당 친구 요청의 receiver가 세션 자기 자신인지 확인
+        if (!friendRequest.getReceiver().getId().equals(memberId)) {
+            throw new FriendException(FriendErrorCode.FRIEND_REQUEST_FORBIDDEN);
+        }
+        return friendRequest;
     }
 }

--- a/src/main/java/com/project/backend/domain/friend/service/command/FriendCommandServiceImpl.java
+++ b/src/main/java/com/project/backend/domain/friend/service/command/FriendCommandServiceImpl.java
@@ -1,11 +1,100 @@
 package com.project.backend.domain.friend.service.command;
 
+import com.project.backend.domain.friend.converter.FriendConverter;
+import com.project.backend.domain.friend.converter.FriendRequestConverter;
+import com.project.backend.domain.friend.dto.request.FriendReqDTO;
+import com.project.backend.domain.friend.entity.Friend;
+import com.project.backend.domain.friend.entity.FriendRequest;
+import com.project.backend.domain.friend.exception.FriendErrorCode;
+import com.project.backend.domain.friend.exception.FriendException;
+import com.project.backend.domain.friend.repository.FriendRepository;
+import com.project.backend.domain.friend.repository.FriendRequestRepository;
+import com.project.backend.domain.member.entity.Member;
+import com.project.backend.domain.member.enums.Role;
+import com.project.backend.domain.member.exception.MemberErrorCode;
+import com.project.backend.domain.member.exception.MemberException;
+import com.project.backend.domain.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional
 public class FriendCommandServiceImpl implements FriendCommandService{
+
+    private final MemberRepository memberRepository;
+    private final FriendRepository friendRepository;
+    private final FriendRequestRepository friendRequestRepository;
+
+    @Override
+    public void sendRequest(Long memberId, FriendReqDTO.SendRequestReq reqDTO) {
+
+        // 요청자 객체
+        Member requester = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
+
+        // memberId : 요청자, reqDTO.email() : 피요청자
+        // 피요청자 객체
+        // 이미 친구이거나, 친구 요청을 보낸 상태라면 409 반환
+        Member requestTarget = getRequestTarget(memberId, reqDTO.email());
+
+        // 만약 피요청자가 요청자에게 친구 요청 조회
+        FriendRequest reversedFriendRequest =
+                friendRequestRepository.findBySenderIdAndReceiverId(requestTarget.getId(), memberId)
+                        .orElse(null);
+
+        // 만약 피요청자가 요청자에게 친구 요청을 보냈다면
+        if (reversedFriendRequest != null) {
+            // 쌍방향 저장을 위한 친구 객체 생성
+            List<Friend> friendships = List.of(
+                    FriendConverter.toFriend(requester, requestTarget),
+                    FriendConverter.toFriend(requestTarget, requester)
+            );
+            // 저장
+            try {
+                friendRepository.saveAll(friendships);
+            } catch (DataIntegrityViolationException e) {
+                throw new FriendException(FriendErrorCode.FRIEND_SAVE_CONFLICT);
+            }
+            // 저장 완료 후 요청 정보 삭제
+            friendRequestRepository.delete(reversedFriendRequest);
+            return;
+        }
+
+        // 피요청자가 요청자에게 친구 요청을 보내지 않았다면
+        // 요청 객체 생성
+        FriendRequest friendRequest = FriendRequestConverter.toFriendRequest(requester, requestTarget);
+        // 저장
+        try {
+            friendRequestRepository.save(friendRequest);
+        } catch (DataIntegrityViolationException e) {
+            throw new FriendException(FriendErrorCode.FRIEND_REQUEST_SAVE_CONFLICT);
+        }
+    }
+
+    private Member getRequestTarget(Long memberId, String email) {
+        // 관리자가 아닌 유저이면서, 자기 자신이 아닌 피요청자 객체 검색
+        Member requestTarget = memberRepository.findByEmailAndRoleAndIdNot(email, Role.ROLE_USER, memberId)
+                .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
+
+        // 이미 친구인 경우
+        boolean alreadyFriend = friendRepository.existsByMemberIdAndFriendId(memberId, requestTarget.getId());
+        if (alreadyFriend) {
+            throw new FriendException(FriendErrorCode.ALREADY_FRIEND);
+        }
+
+        // 이미 친구 요청이 보내진 경우
+        boolean alreadyRequested = friendRequestRepository.existsBySenderIdAndReceiverId(memberId, requestTarget.getId());
+        if (alreadyRequested) {
+            throw new FriendException(FriendErrorCode.ALREADY_REQUESTED);
+        }
+
+        return requestTarget;
+    }
 }

--- a/src/main/java/com/project/backend/domain/friend/service/command/FriendCommandServiceImpl.java
+++ b/src/main/java/com/project/backend/domain/friend/service/command/FriendCommandServiceImpl.java
@@ -1,0 +1,11 @@
+package com.project.backend.domain.friend.service.command;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class FriendCommandServiceImpl implements FriendCommandService{
+}

--- a/src/main/java/com/project/backend/domain/friend/service/command/FriendCommandServiceImpl.java
+++ b/src/main/java/com/project/backend/domain/friend/service/command/FriendCommandServiceImpl.java
@@ -36,17 +36,17 @@ public class FriendCommandServiceImpl implements FriendCommandService{
     public void sendRequest(Long memberId, FriendReqDTO.SendRequestReq reqDTO) {
 
         // 요청자 객체
-        Member requester = memberRepository.findById(memberId)
+        Member me = memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
 
         // memberId : 요청자, reqDTO.email() : 피요청자
         // 피요청자 객체
         // 이미 친구이거나, 친구 요청을 보낸 상태라면 409 반환
-        Member requestTarget = getRequestTarget(memberId, reqDTO.email());
+        Member opponent = getOpponent(memberId, reqDTO.email());
 
         // 만약 피요청자가 요청자에게 친구 요청 조회
         FriendRequest reversedFriendRequest =
-                friendRequestRepository.findBySenderIdAndReceiverId(requestTarget.getId(), memberId)
+                friendRequestRepository.findBySenderIdAndReceiverId(opponent.getId(), memberId)
                         .orElse(null);
 
         // 만약 피요청자가 요청자에게 친구 요청을 보냈다면
@@ -57,7 +57,7 @@ public class FriendCommandServiceImpl implements FriendCommandService{
 
         // 피요청자가 요청자에게 친구 요청을 보내지 않았다면
         // 요청 객체 생성
-        FriendRequest friendRequest = FriendRequestConverter.toFriendRequest(requester, requestTarget);
+        FriendRequest friendRequest = FriendRequestConverter.toFriendRequest(me, opponent);
         // 저장
         try {
             friendRequestRepository.save(friendRequest);
@@ -83,24 +83,44 @@ public class FriendCommandServiceImpl implements FriendCommandService{
         friendRequestRepository.delete(friendRequest);
     }
 
-    private Member getRequestTarget(Long memberId, String email) {
+    @Override
+    public void deleteFriend(Long memberId, Long friendId) {
+        // 내가 가진 나 -> 친구 (일방향 친구 객체)
+        Friend friend = friendRepository.findById(friendId)
+                .orElseThrow(() -> new FriendException(FriendErrorCode.FRIEND_NOT_FOUND));
+        // 소유권 검사
+        if (!friend.getMember().getId().equals(memberId)) {
+            throw new FriendException(FriendErrorCode.FRIEND_FORBIDDEN);
+        }
+        // 친구 객체
+        Member opponent = friend.getOpponent();
+        // 쌍방향 친구 조회
+        Friend opponentFriend = friendRepository.findByMemberIdAndOpponentId(opponent.getId(), memberId)
+                .orElseThrow(() -> new FriendException(FriendErrorCode.FRIEND_NOT_FOUND));
+
+        // 쌍방향 친구 삭제
+        friendRepository.delete(opponentFriend);
+        friendRepository.delete(friend);
+    }
+
+    private Member getOpponent(Long memberId, String email) {
         // 관리자가 아닌 유저이면서, 자기 자신이 아닌 피요청자 객체 검색
-        Member requestTarget = memberRepository.findByEmailAndRoleAndIdNot(email, Role.ROLE_USER, memberId)
+        Member opponent = memberRepository.findByEmailAndRoleAndIdNot(email, Role.ROLE_USER, memberId)
                 .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
 
         // 이미 친구인 경우
-        boolean alreadyFriend = friendRepository.existsByMemberIdAndFriendId(memberId, requestTarget.getId());
+        boolean alreadyFriend = friendRepository.existsByMemberIdAndOpponentId(memberId, opponent.getId());
         if (alreadyFriend) {
             throw new FriendException(FriendErrorCode.ALREADY_FRIEND);
         }
 
         // 이미 친구 요청이 보내진 경우
-        boolean alreadyRequested = friendRequestRepository.existsBySenderIdAndReceiverId(memberId, requestTarget.getId());
+        boolean alreadyRequested = friendRequestRepository.existsBySenderIdAndReceiverId(memberId, opponent.getId());
         if (alreadyRequested) {
             throw new FriendException(FriendErrorCode.ALREADY_REQUESTED);
         }
 
-        return requestTarget;
+        return opponent;
     }
 
     private void saveFriend(FriendRequest friendRequest) {

--- a/src/main/java/com/project/backend/domain/friend/service/query/FriendQueryService.java
+++ b/src/main/java/com/project/backend/domain/friend/service/query/FriendQueryService.java
@@ -1,4 +1,8 @@
 package com.project.backend.domain.friend.service.query;
 
+import com.project.backend.domain.friend.dto.response.FriendResDTO;
+
 public interface FriendQueryService {
+
+    FriendResDTO.FriendRequestListRes getSentFriendRequest(Long memberId);
 }

--- a/src/main/java/com/project/backend/domain/friend/service/query/FriendQueryService.java
+++ b/src/main/java/com/project/backend/domain/friend/service/query/FriendQueryService.java
@@ -7,4 +7,6 @@ public interface FriendQueryService {
     FriendResDTO.FriendRequestListRes getSentFriendRequest(Long memberId);
 
     FriendResDTO.FriendRequestListRes getReceivedFriendRequest(Long memberId);
+
+    FriendResDTO.FriendListRes getFriend(Long memberId);
 }

--- a/src/main/java/com/project/backend/domain/friend/service/query/FriendQueryService.java
+++ b/src/main/java/com/project/backend/domain/friend/service/query/FriendQueryService.java
@@ -1,0 +1,4 @@
+package com.project.backend.domain.friend.service.query;
+
+public interface FriendQueryService {
+}

--- a/src/main/java/com/project/backend/domain/friend/service/query/FriendQueryService.java
+++ b/src/main/java/com/project/backend/domain/friend/service/query/FriendQueryService.java
@@ -5,4 +5,6 @@ import com.project.backend.domain.friend.dto.response.FriendResDTO;
 public interface FriendQueryService {
 
     FriendResDTO.FriendRequestListRes getSentFriendRequest(Long memberId);
+
+    FriendResDTO.FriendRequestListRes getReceivedFriendRequest(Long memberId);
 }

--- a/src/main/java/com/project/backend/domain/friend/service/query/FriendQueryServiceImpl.java
+++ b/src/main/java/com/project/backend/domain/friend/service/query/FriendQueryServiceImpl.java
@@ -1,8 +1,11 @@
 package com.project.backend.domain.friend.service.query;
 
+import com.project.backend.domain.friend.converter.FriendConverter;
 import com.project.backend.domain.friend.converter.FriendRequestConverter;
 import com.project.backend.domain.friend.dto.response.FriendResDTO;
+import com.project.backend.domain.friend.entity.Friend;
 import com.project.backend.domain.friend.entity.FriendRequest;
+import com.project.backend.domain.friend.repository.FriendRepository;
 import com.project.backend.domain.friend.repository.FriendRequestRepository;
 import com.project.backend.domain.member.entity.Member;
 import com.project.backend.domain.member.exception.MemberErrorCode;
@@ -21,6 +24,7 @@ public class FriendQueryServiceImpl implements FriendQueryService{
 
     private final MemberRepository memberRepository;
     private final FriendRequestRepository friendRequestRepository;
+    private final FriendRepository friendRepository;
 
     @Override
     public FriendResDTO.FriendRequestListRes getSentFriendRequest(Long memberId) {
@@ -38,6 +42,18 @@ public class FriendQueryServiceImpl implements FriendQueryService{
         // 세션 자기 자신이 받은 친구 요청 리스트 조회
         List<FriendRequest> friendRequests = friendRequestRepository.findByReceiverId(memberId);
         return buildFriendRequestList(friendRequests, me);
+    }
+
+    @Override
+    public FriendResDTO.FriendListRes getFriend(Long memberId) {
+        // 모든 친구 조회
+        List<Friend> friendList = friendRepository.findByMemberId(memberId);
+        // List<Friend> -> List<FriendDetailRes>
+        List<FriendResDTO.FriendDetailRes> detailResList = friendList.stream()
+                .map(FriendConverter::toFriendDetailRes)
+                .toList();
+
+        return FriendConverter.toFriendList(detailResList);
     }
 
     // id로 멤버 객체를 조회

--- a/src/main/java/com/project/backend/domain/friend/service/query/FriendQueryServiceImpl.java
+++ b/src/main/java/com/project/backend/domain/friend/service/query/FriendQueryServiceImpl.java
@@ -22,27 +22,45 @@ public class FriendQueryServiceImpl implements FriendQueryService{
     private final MemberRepository memberRepository;
     private final FriendRequestRepository friendRequestRepository;
 
-
     @Override
     public FriendResDTO.FriendRequestListRes getSentFriendRequest(Long memberId) {
-
         // 세션 멤버 객체 조회
-        Member sender = memberRepository.findById(memberId)
-                .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
-
+        Member me = getMember(memberId);
         // 세션 자기 자신이 보낸 친구 요청 리스트 조회
         List<FriendRequest> friendRequests = friendRequestRepository.findBySenderId(memberId);
+        return buildFriendRequestList(friendRequests, me);
+    }
 
-        // List<FriendRequest> -> List<FriendRequestDetailRes>
-        List<FriendResDTO.FriendRequestDetailRes> friendRequestDetailResList =
-                friendRequests.stream()
-                        .map(friendRequest -> { // 각각의 요청에 대하여 receiver 정보를 조회해 dto에 담기
-                            Member receiver = memberRepository.findById(friendRequest.getReceiver().getId())
-                                    .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
-                            return FriendRequestConverter.toFriendRequestDetailRes(friendRequest, sender, receiver);
-                        })
-                        .toList();
+    @Override
+    public FriendResDTO.FriendRequestListRes getReceivedFriendRequest(Long memberId) {
+        // 세션 멤버 객체 조회
+        Member me = getMember(memberId);
+        // 세션 자기 자신이 받은 친구 요청 리스트 조회
+        List<FriendRequest> friendRequests = friendRequestRepository.findByReceiverId(memberId);
+        return buildFriendRequestList(friendRequests, me);
+    }
 
-        return FriendRequestConverter.toFriendRequestList(friendRequestDetailResList);
+    // id로 멤버 객체를 조회
+    private Member getMember(Long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
+    }
+
+    private FriendResDTO.FriendRequestListRes buildFriendRequestList(
+            List<FriendRequest> friendRequests,
+            Member me
+    ) {
+        List<FriendResDTO.FriendRequestDetailRes> detailResList = friendRequests.stream()
+                .map(friendRequest -> {
+                    // friendRequest의 receiver가 자기 자신인가?
+                    boolean sentByMe = friendRequest.getSender().getId().equals(me.getId());
+                    // 만약 나라면 상대를 receiver로 설정, 내가 아니라면 상대를 sender로 설정
+                    Member opponent = sentByMe ? friendRequest.getReceiver() : friendRequest.getSender();
+                    // 상대 정보를 기준으로 detail 생성
+                    return FriendRequestConverter.toFriendRequestDetailRes(friendRequest, opponent);
+                })
+                .toList();
+
+        return FriendRequestConverter.toFriendRequestList(detailResList);
     }
 }

--- a/src/main/java/com/project/backend/domain/friend/service/query/FriendQueryServiceImpl.java
+++ b/src/main/java/com/project/backend/domain/friend/service/query/FriendQueryServiceImpl.java
@@ -1,11 +1,48 @@
 package com.project.backend.domain.friend.service.query;
 
+import com.project.backend.domain.friend.converter.FriendRequestConverter;
+import com.project.backend.domain.friend.dto.response.FriendResDTO;
+import com.project.backend.domain.friend.entity.FriendRequest;
+import com.project.backend.domain.friend.repository.FriendRequestRepository;
+import com.project.backend.domain.member.entity.Member;
+import com.project.backend.domain.member.exception.MemberErrorCode;
+import com.project.backend.domain.member.exception.MemberException;
+import com.project.backend.domain.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 @Transactional
 public class FriendQueryServiceImpl implements FriendQueryService{
+
+    private final MemberRepository memberRepository;
+    private final FriendRequestRepository friendRequestRepository;
+
+
+    @Override
+    public FriendResDTO.FriendRequestListRes getSentFriendRequest(Long memberId) {
+
+        // 세션 멤버 객체 조회
+        Member sender = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
+
+        // 세션 자기 자신이 보낸 친구 요청 리스트 조회
+        List<FriendRequest> friendRequests = friendRequestRepository.findBySenderId(memberId);
+
+        // List<FriendRequest> -> List<FriendRequestDetailRes>
+        List<FriendResDTO.FriendRequestDetailRes> friendRequestDetailResList =
+                friendRequests.stream()
+                        .map(friendRequest -> { // 각각의 요청에 대하여 receiver 정보를 조회해 dto에 담기
+                            Member receiver = memberRepository.findById(friendRequest.getReceiver().getId())
+                                    .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
+                            return FriendRequestConverter.toFriendRequestDetailRes(friendRequest, sender, receiver);
+                        })
+                        .toList();
+
+        return FriendRequestConverter.toFriendRequestList(friendRequestDetailResList);
+    }
 }

--- a/src/main/java/com/project/backend/domain/friend/service/query/FriendQueryServiceImpl.java
+++ b/src/main/java/com/project/backend/domain/friend/service/query/FriendQueryServiceImpl.java
@@ -1,0 +1,11 @@
+package com.project.backend.domain.friend.service.query;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class FriendQueryServiceImpl implements FriendQueryService{
+}

--- a/src/main/java/com/project/backend/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/project/backend/domain/member/repository/MemberRepository.java
@@ -1,6 +1,7 @@
 package com.project.backend.domain.member.repository;
 
 import com.project.backend.domain.member.entity.Member;
+import com.project.backend.domain.member.enums.Role;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -32,5 +33,8 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     // Auth 정보와 함께 활성 회원 조회
     @Query("SELECT m FROM Member m JOIN FETCH m.auth WHERE m.id = :id AND m.deletedAt IS NULL")
     Optional<Member> findActiveByIdWithAuth(@Param("id") Long id);
+
+    // 친구 피요청자의 객체 조회 (역할이 유저이며, 세션 멤버 자기 자신이 아닌)
+    Optional<Member> findByEmailAndRoleAndIdNot(String email, Role role, Long memberId);
 
 }


### PR DESCRIPTION
# ☝️Issue Number

#161 

##  📌 개요

- ebc751fe86d62aa271d9b18d48370d0b555bf88c
  - friend 도메인 생성

- 78a4827a6395638b55d73c02dc81e6c356dc91d3 0f26a06b3af48f28b2f11862a519fffd1bcb7c75 1bf7793ff717b1cc53f97d6645490a07b9394b82
  - 친구 요청만을 저장하는 FriendRequestEntity
  - enum 추가
  - 엔티티 구현

- abf3801de53992132d59861d6fa737b64f7273b6
  - 친구 요청 구현

- fad7f688d5a7c09cd2797bfd1f9f009793cd9331
  - 보낸 친구 목록 조회

- 81a781dcb4ec9aa2f54c82c52340006f4ff52866
  - 받은 친구 목록 조회 + 보낸 친구 목록 조회와 공통 부분 리팩토링

- 74a25a2750a92871e493e602dac03aa2d47487d8
  - 친구 요청 수락 구현

- d11f18e94d28fc12de7f651a11337891f8d0e0da
  - 친구 요청 거절 구현 + 친구 요청 수락 구현과 공통 부분 리팩토링

- 3e54a274b7264b976467787968e9d5d4b6820e6d
  - 모든 친구 목록 조회

- 27c6ce4cbdee8da7cbb1797282ee1528117d7d7f
  - Friend 엔티티의 Member 타입 필드 friend -> opponent로 변경
  - friend_id를 사용하면 엔티티의 id인지 필드 객체의 id인지 헷갈릴 수 있어서 변경

- cfce276b9462e4aa24441ca613bae1efe6853f00
  - 친구 삭제 구현

- 4313ffd7c20ecd3d65e20e682e2c4927931f0c53
  - CREATED, NO_CONTENT HttpStatus 추가

- 56cbebdb7756e5db3d65b4f4f6a2963fff2703ce
  - api/v1/friends/requests/~~ -> api/v1/friends & api/v1/friend-requests/~~~ 로 분리

- e1eaf8b662a0998f1641a782a3945cb8345d758b
  - FriendRequest가 더이상 상태를 가지지 않음
  - 해당 테이블에 존재하면 요청 중인 상태이며
  - 수락이나 거절시 삭제
  - 따라서 상태를 나타내는 enum을 더 이상 사용하지 않아 삭제

## 🔁 변경 사항

## 📸 스크린샷

## 👀 기타 더 이야기해볼 점
- 회원 탈퇴시 친구 조회를 어떻게 할 지
  - 쿼리문을 not deleled로 해서 안보이게 하면 될지 아니면 탈퇴한 회원이라고 표시할 지