### PR TITLE
Feat/#161 친구 API 변경 사항 적용 & 자잘한 수정

### DIFF
--- a/src/main/java/com/project/backend/domain/friend/controller/FriendController.java
+++ b/src/main/java/com/project/backend/domain/friend/controller/FriendController.java
@@ -47,6 +47,15 @@ public class FriendController implements FriendDocs{
         return CustomResponse.onSuccess("친구 목록 조회 완료", resDTO);
     }
 
+    @GetMapping("/friends/search")
+    public CustomResponse<FriendResDTO.FriendListRes> searchFriend(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails,
+            @RequestParam(required = false) String keyword
+    ) {
+        FriendResDTO.FriendListRes resDTO = friendQueryService.searchFriend(customUserDetails.getId(), keyword);
+        return CustomResponse.onSuccess("친구 검색 완료", resDTO);
+    }
+
     @Override
     @PostMapping("/friend-requests")
     public CustomResponse<String> sendRequest(

--- a/src/main/java/com/project/backend/domain/friend/controller/FriendController.java
+++ b/src/main/java/com/project/backend/domain/friend/controller/FriendController.java
@@ -53,7 +53,7 @@ public class FriendController {
         return CustomResponse.onSuccess(HttpStatus.CREATED, "친구 요청 완료", null);
     }
 
-    @PostMapping("/friend-reqeusts/{friendRequestId}/accept")
+    @PostMapping("/friend-requests/{friendRequestId}/accept")
     public CustomResponse<String> acceptFriendRequest(
             @AuthenticationPrincipal CustomUserDetails customUserDetails,
             @PathVariable Long friendRequestId
@@ -62,7 +62,7 @@ public class FriendController {
         return CustomResponse.onSuccess("친구 요청 수락 완료", null);
     }
 
-    @PostMapping("/friend-reqeusts/{friendRequestId}/reject")
+    @PostMapping("/friend-requests/{friendRequestId}/reject")
     public CustomResponse<String> rejectFriendRequest(
             @AuthenticationPrincipal CustomUserDetails customUserDetails,
             @PathVariable Long friendRequestId

--- a/src/main/java/com/project/backend/domain/friend/controller/FriendController.java
+++ b/src/main/java/com/project/backend/domain/friend/controller/FriendController.java
@@ -15,11 +15,12 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1")
-public class FriendController {
+public class FriendController implements FriendDocs{
 
     private final FriendCommandService friendCommandService;
     private final FriendQueryService friendQueryService;
 
+    @Override
     @GetMapping("/friend-requests/sent")
     public CustomResponse<FriendResDTO.FriendRequestListRes> getSentFriendRequest(
             @AuthenticationPrincipal CustomUserDetails customUserDetails
@@ -28,6 +29,7 @@ public class FriendController {
         return CustomResponse.onSuccess("보낸 친구 요청 목록 조회 완료", resDTO);
     }
 
+    @Override
     @GetMapping("/friend-requests/received")
     public CustomResponse<FriendResDTO.FriendRequestListRes> getReceivedFriendRequest(
             @AuthenticationPrincipal CustomUserDetails customUserDetails
@@ -36,6 +38,7 @@ public class FriendController {
         return CustomResponse.onSuccess("받은 친구 요청 목록 조회 완료", resDTO);
     }
 
+    @Override
     @GetMapping("/friends")
     public CustomResponse<FriendResDTO.FriendListRes> getFriend(
             @AuthenticationPrincipal CustomUserDetails customUserDetails
@@ -44,6 +47,7 @@ public class FriendController {
         return CustomResponse.onSuccess("친구 목록 조회 완료", resDTO);
     }
 
+    @Override
     @PostMapping("/friend-requests")
     public CustomResponse<String> sendRequest(
             @AuthenticationPrincipal CustomUserDetails customUserDetails,
@@ -53,6 +57,7 @@ public class FriendController {
         return CustomResponse.onSuccess(HttpStatus.CREATED, "친구 요청 완료", null);
     }
 
+    @Override
     @PostMapping("/friend-requests/{friendRequestId}/accept")
     public CustomResponse<String> acceptFriendRequest(
             @AuthenticationPrincipal CustomUserDetails customUserDetails,
@@ -62,6 +67,7 @@ public class FriendController {
         return CustomResponse.onSuccess("친구 요청 수락 완료", null);
     }
 
+    @Override
     @PostMapping("/friend-requests/{friendRequestId}/reject")
     public CustomResponse<String> rejectFriendRequest(
             @AuthenticationPrincipal CustomUserDetails customUserDetails,
@@ -71,6 +77,7 @@ public class FriendController {
         return CustomResponse.onSuccess("친구 요청 거절 완료", null);
     }
 
+    @Override
     @DeleteMapping("/friends/{friendId}")
     public CustomResponse<String> deleteFriend(
             @AuthenticationPrincipal CustomUserDetails customUserDetails,

--- a/src/main/java/com/project/backend/domain/friend/controller/FriendDocs.java
+++ b/src/main/java/com/project/backend/domain/friend/controller/FriendDocs.java
@@ -1,0 +1,402 @@
+package com.project.backend.domain.friend.controller;
+
+import com.project.backend.domain.friend.dto.request.FriendReqDTO;
+import com.project.backend.domain.friend.dto.response.FriendResDTO;
+import com.project.backend.global.apiPayload.CustomResponse;
+import com.project.backend.global.security.userdetails.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@Tag(name = "친구 API", description = "친구 요청 및 친구 관계 관리 API")
+public interface FriendDocs {
+
+    @Operation(
+            summary = "보낸 친구 요청 목록 조회",
+            description = "인증된 사용자가 보낸 친구 요청 목록을 조회합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "보낸 친구 요청 목록 조회 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = CustomResponse.class)
+                    )
+            )
+    })
+    CustomResponse<FriendResDTO.FriendRequestListRes> getSentFriendRequest(
+            @AuthenticationPrincipal
+            @Parameter(hidden = true)
+            CustomUserDetails customUserDetails
+    );
+
+    @Operation(
+            summary = "받은 친구 요청 목록 조회",
+            description = "인증된 사용자가 받은 친구 요청 목록을 조회합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "받은 친구 요청 목록 조회 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = CustomResponse.class)
+                    )
+            )
+    })
+    CustomResponse<FriendResDTO.FriendRequestListRes> getReceivedFriendRequest(
+            @AuthenticationPrincipal
+            @Parameter(hidden = true)
+            CustomUserDetails customUserDetails
+    );
+
+    @Operation(
+            summary = "친구 목록 조회",
+            description = "인증된 사용자의 친구 목록을 조회합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "친구 목록 조회 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = CustomResponse.class)
+                    )
+            )
+    })
+    CustomResponse<FriendResDTO.FriendListRes> getFriend(
+            @AuthenticationPrincipal
+            @Parameter(hidden = true)
+            CustomUserDetails customUserDetails
+    );
+
+    @Operation(
+            summary = "친구 요청 전송",
+            description = """
+                    이메일로 다른 사용자에게 친구 요청을 전송합니다.
+
+                    - 이미 친구인 경우 409를 반환합니다.
+                    - 이미 친구 요청을 보낸 경우 409를 반환합니다.
+                    - 상대방이 나에게 보낸 친구 요청이 이미 있으면 자동으로 친구가 됩니다.
+                    """
+    )
+    @RequestBody(
+            required = true,
+            description = "친구 요청 대상 이메일",
+            content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = FriendReqDTO.SendRequestReq.class)
+            )
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "201",
+                    description = "친구 요청 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = CustomResponse.class),
+                            examples = @ExampleObject(
+                                    name = "친구 요청 성공 예시",
+                                    value = """
+                                            {
+                                              "isSuccess": true,
+                                              "code": "COMMON201",
+                                              "message": "친구 요청 완료",
+                                              "result": null
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "409",
+                    description = "이미 친구 / 이미 요청됨",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = CustomResponse.class),
+                            examples = {
+                                    @ExampleObject(
+                                            name = "ALREADY_FRIEND",
+                                            summary = "이미 친구인 경우",
+                                            value = """
+                                                    {
+                                                      "isSuccess": false,
+                                                      "code": "FRIEND409_1",
+                                                      "message": "이미 친구입니다.",
+                                                      "result": null
+                                                    }
+                                                    """
+                                    ),
+                                    @ExampleObject(
+                                            name = "ALREADY_REQUESTED",
+                                            summary = "이미 친구 요청을 보낸 경우",
+                                            value = """
+                                                    {
+                                                      "isSuccess": false,
+                                                      "code": "FRIEND409_2",
+                                                      "message": "이미 친구 요청이 전송되었습니다",
+                                                      "result": null
+                                                    }
+                                                    """
+                                    )
+                            }
+                    )
+            )
+    })
+    CustomResponse<String> sendRequest(
+            @AuthenticationPrincipal
+            @Parameter(hidden = true)
+            CustomUserDetails customUserDetails,
+            @org.springframework.web.bind.annotation.RequestBody @Valid FriendReqDTO.SendRequestReq reqDTO
+    );
+
+    @Operation(
+            summary = "친구 요청 수락",
+            description = """
+                    받은 친구 요청을 수락합니다.
+
+                    - 친구 요청의 receiver 본인만 수락할 수 있습니다.
+                    - 수락 시 양방향 친구 관계가 생성되고 기존 친구 요청은 삭제됩니다.
+                    """
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "친구 요청 수락 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = CustomResponse.class),
+                            examples = @ExampleObject(
+                                    name = "친구 요청 수락 성공 예시",
+                                    value = """
+                                            {
+                                              "isSuccess": true,
+                                              "code": "COMMON200",
+                                              "message": "친구 요청 수락 완료",
+                                              "result": null
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "403",
+                    description = "해당 친구 요청에 대한 접근 권한이 없음",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = CustomResponse.class),
+                            examples = @ExampleObject(
+                                    name = "FRIEND_REQUEST_FORBIDDEN",
+                                    value = """
+                                            {
+                                              "isSuccess": false,
+                                              "code": "FRIEND403_1",
+                                              "message": "해당 친구 요청에 대한 접근 권한이 없습니다",
+                                              "result": null
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "친구 요청을 찾을 수 없음",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = CustomResponse.class),
+                            examples = @ExampleObject(
+                                    name = "FRIEND_REQUEST_NOT_FOUND",
+                                    value = """
+                                            {
+                                              "isSuccess": false,
+                                              "code": "FRIEND404_1",
+                                              "message": "해당 친구 요청을 찾을 수 없습니다",
+                                              "result": null
+                                            }
+                                            """
+                            )
+                    )
+            )
+    })
+    CustomResponse<String> acceptFriendRequest(
+            @AuthenticationPrincipal
+            @Parameter(hidden = true)
+            CustomUserDetails customUserDetails,
+
+            @Parameter(
+                    description = "수락할 친구 요청 ID",
+                    required = true
+            )
+            @PathVariable Long friendRequestId
+    );
+
+    @Operation(
+            summary = "친구 요청 거절",
+            description = """
+                    받은 친구 요청을 거절합니다.
+
+                    - 친구 요청의 receiver 본인만 거절할 수 있습니다.
+                    - 거절 시 친구 요청은 삭제됩니다.
+                    """
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "친구 요청 거절 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = CustomResponse.class),
+                            examples = @ExampleObject(
+                                    name = "친구 요청 거절 성공 예시",
+                                    value = """
+                                            {
+                                              "isSuccess": true,
+                                              "code": "COMMON200",
+                                              "message": "친구 요청 거절 완료",
+                                              "result": null
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "403",
+                    description = "해당 친구 요청에 대한 접근 권한이 없음",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = CustomResponse.class),
+                            examples = @ExampleObject(
+                                    name = "FRIEND_REQUEST_FORBIDDEN",
+                                    value = """
+                                            {
+                                              "isSuccess": false,
+                                              "code": "FRIEND403_1",
+                                              "message": "해당 친구 요청에 대한 접근 권한이 없습니다",
+                                              "result": null
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "친구 요청을 찾을 수 없음",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = CustomResponse.class),
+                            examples = @ExampleObject(
+                                    name = "FRIEND_REQUEST_NOT_FOUND",
+                                    value = """
+                                            {
+                                              "isSuccess": false,
+                                              "code": "FRIEND404_1",
+                                              "message": "해당 친구 요청을 찾을 수 없습니다",
+                                              "result": null
+                                            }
+                                            """
+                            )
+                    )
+            )
+    })
+    CustomResponse<String> rejectFriendRequest(
+            @AuthenticationPrincipal
+            @Parameter(hidden = true)
+            CustomUserDetails customUserDetails,
+
+            @Parameter(
+                    description = "거절할 친구 요청 ID",
+                    required = true
+            )
+            @PathVariable Long friendRequestId
+    );
+
+    @Operation(
+            summary = "친구 삭제",
+            description = """
+                    친구 관계를 삭제합니다.
+
+                    - 현재 사용자가 소유한 친구 관계만 삭제할 수 있습니다.
+                    - 삭제 시 상대방의 친구 관계도 함께 삭제됩니다.
+                    """
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "친구 삭제 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = CustomResponse.class),
+                            examples = @ExampleObject(
+                                    name = "친구 삭제 성공 예시",
+                                    value = """
+                                            {
+                                              "isSuccess": true,
+                                              "code": "COMMON200",
+                                              "message": "친구 삭제 완료",
+                                              "result": null
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "403",
+                    description = "해당 친구에 대한 접근 권한이 없음",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = CustomResponse.class),
+                            examples = @ExampleObject(
+                                    name = "FRIEND_FORBIDDEN",
+                                    value = """
+                                            {
+                                              "isSuccess": false,
+                                              "code": "FRIEND403_2",
+                                              "message": "해당 친구에 대한 접근 권한이 없습니다",
+                                              "result": null
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "친구를 찾을 수 없음",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = CustomResponse.class),
+                            examples = @ExampleObject(
+                                    name = "FRIEND_NOT_FOUND",
+                                    value = """
+                                            {
+                                              "isSuccess": false,
+                                              "code": "FRIEND404_2",
+                                              "message": "해당 친구를 찾을 수 없습니다",
+                                              "result": null
+                                            }
+                                            """
+                            )
+                    )
+            )
+    })
+    CustomResponse<String> deleteFriend(
+            @AuthenticationPrincipal
+            @Parameter(hidden = true)
+            CustomUserDetails customUserDetails,
+
+            @Parameter(
+                    description = "삭제할 친구 ID",
+                    required = true
+            )
+            @PathVariable Long friendId
+    );
+}

--- a/src/main/java/com/project/backend/domain/friend/controller/FriendDocs.java
+++ b/src/main/java/com/project/backend/domain/friend/controller/FriendDocs.java
@@ -16,6 +16,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "친구 API", description = "친구 요청 및 친구 관계 관리 API")
 public interface FriendDocs {
@@ -83,7 +84,7 @@ public interface FriendDocs {
     @Operation(
             summary = "친구 요청 전송",
             description = """
-                    이메일로 다른 사용자에게 친구 요청을 전송합니다.
+                    이름과 이메일로 다른 사용자에게 친구 요청을 전송합니다.
 
                     - 이미 친구인 경우 409를 반환합니다.
                     - 이미 친구 요청을 보낸 경우 409를 반환합니다.
@@ -398,5 +399,28 @@ public interface FriendDocs {
                     required = true
             )
             @PathVariable Long friendId
+    );
+
+    @Operation(
+            summary = "친구 검색",
+            description = "인증된 사용자의 친구 목록에서 keyword를 기준으로 친구를 검색합니다. keyword가 없으면 전체 친구 목록을 조회합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "친구 검색 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = CustomResponse.class)
+                    )
+            )
+    })
+    CustomResponse<FriendResDTO.FriendListRes> searchFriend(
+            @AuthenticationPrincipal
+            @Parameter(hidden = true)
+            CustomUserDetails customUserDetails,
+
+            @RequestParam(required = false)
+            String keyword
     );
 }

--- a/src/main/java/com/project/backend/domain/friend/dto/request/FriendReqDTO.java
+++ b/src/main/java/com/project/backend/domain/friend/dto/request/FriendReqDTO.java
@@ -6,6 +6,9 @@ import jakarta.validation.constraints.NotBlank;
 public class FriendReqDTO {
 
     public record SendRequestReq(
+            @NotBlank
+            String name,
+
             @Email
             @NotBlank
             String email

--- a/src/main/java/com/project/backend/domain/friend/entity/Friend.java
+++ b/src/main/java/com/project/backend/domain/friend/entity/Friend.java
@@ -11,7 +11,7 @@ import lombok.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Table(name = "friend",
-        uniqueConstraints = @UniqueConstraint(columnNames = {"member_id", "friend_id"}))
+        uniqueConstraints = @UniqueConstraint(columnNames = {"member_id", "opponent_id"}))
 public class Friend extends BaseEntity {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/project/backend/domain/friend/repository/FriendRepository.java
+++ b/src/main/java/com/project/backend/domain/friend/repository/FriendRepository.java
@@ -1,7 +1,9 @@
 package com.project.backend.domain.friend.repository;
 
 import com.project.backend.domain.friend.entity.Friend;
+import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -19,4 +21,22 @@ public interface FriendRepository extends JpaRepository<Friend, Long> {
     // memberId와 OpponentId로 친구 찾기
     Optional<Friend> findByMemberIdAndOpponentId(Long memberId, Long friendId);
 
+    // 입력한 keyword와 유사한 이름을 가진 친구 객체 찾기
+    @Query("SELECT f " +
+            "FROM Friend f " +
+            "JOIN Member m ON m.id = f.opponent.id " +
+            "WHERE f.member.id = :memberId " +
+            "AND m.nickname LIKE CONCAT('%', :keyword, '%') " +
+            "ORDER BY " +
+                "CASE " +
+                    "WHEN m.nickname LIKE CONCAT(:keyword, '%') THEN 0 " +
+                    "ELSE 1 " +
+                "END, " +
+                "m.nickname ASC " +
+            "LIMIT 20"
+    )
+    List<Friend> findByMemberIdAndKeyword(
+            @Param("memberId") Long memberId,
+            @Param("keyword") String keyword
+    );
 }

--- a/src/main/java/com/project/backend/domain/friend/repository/FriendRepository.java
+++ b/src/main/java/com/project/backend/domain/friend/repository/FriendRepository.java
@@ -3,6 +3,7 @@ package com.project.backend.domain.friend.repository;
 import com.project.backend.domain.friend.entity.Friend;
 import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
@@ -38,5 +39,14 @@ public interface FriendRepository extends JpaRepository<Friend, Long> {
     List<Friend> findByMemberIdAndKeyword(
             @Param("memberId") Long memberId,
             @Param("keyword") String keyword
+    );
+
+    // 회원 탈퇴 시 모든 친구 관련 정보 삭제
+    @Modifying
+    @Query("DELETE " +
+            "FROM Friend f " +
+            "WHERE f.member.id = :memberId OR f.opponent.id = :memberId")
+    void deleteAllByMemberId(
+            @Param("memberId") Long memberId
     );
 }

--- a/src/main/java/com/project/backend/domain/friend/repository/FriendRepository.java
+++ b/src/main/java/com/project/backend/domain/friend/repository/FriendRepository.java
@@ -16,7 +16,7 @@ public interface FriendRepository extends JpaRepository<Friend, Long> {
     boolean existsByMemberIdAndOpponentId(Long memberId, Long friendId);
 
     // memberId로 모든 친구 객체 찬기
-    List<Friend> findByMemberId(Long memberId);
+    List<Friend> findByMemberIdOrderByOpponent_NicknameAsc(Long memberId);
 
     // memberId와 OpponentId로 친구 찾기
     Optional<Friend> findByMemberIdAndOpponentId(Long memberId, Long friendId);

--- a/src/main/java/com/project/backend/domain/friend/repository/FriendRequestRepository.java
+++ b/src/main/java/com/project/backend/domain/friend/repository/FriendRequestRepository.java
@@ -1,7 +1,10 @@
 package com.project.backend.domain.friend.repository;
 
 import com.project.backend.domain.friend.entity.FriendRequest;
+import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -21,4 +24,13 @@ public interface FriendRequestRepository extends JpaRepository<FriendRequest, Lo
 
     // receiverId로 객체 조회
     List<FriendRequest> findByReceiverId(Long memberId);
+
+    // 회원 탈퇴 시 모든 친구 요청 관련 정보 삭제
+    @Modifying
+    @Query("DELETE " +
+            "FROM FriendRequest fr " +
+            "WHERE fr.sender.id = :memberId OR fr.receiver.id =:memberId")
+    void deleteAllByMemberId(
+            @Param("memberId") Long memberId
+    );
 }

--- a/src/main/java/com/project/backend/domain/friend/service/command/FriendCommandServiceImpl.java
+++ b/src/main/java/com/project/backend/domain/friend/service/command/FriendCommandServiceImpl.java
@@ -42,7 +42,7 @@ public class FriendCommandServiceImpl implements FriendCommandService{
         // memberId : 요청자, reqDTO.email() : 피요청자
         // 피요청자 객체
         // 이미 친구이거나, 친구 요청을 보낸 상태라면 409 반환
-        Member opponent = getOpponent(memberId, reqDTO.email());
+        Member opponent = getOpponent(memberId, reqDTO.name(), reqDTO.email());
 
         // 만약 피요청자가 요청자에게 친구 요청 조회
         FriendRequest reversedFriendRequest =
@@ -103,10 +103,11 @@ public class FriendCommandServiceImpl implements FriendCommandService{
         friendRepository.delete(friend);
     }
 
-    private Member getOpponent(Long memberId, String email) {
+    private Member getOpponent(Long memberId, String name, String email) {
         // 관리자가 아닌 유저이면서, 자기 자신이 아닌 피요청자 객체 검색
-        Member opponent = memberRepository.findByEmailAndRoleAndIdNot(email, Role.ROLE_USER, memberId)
+        Member opponent = memberRepository.findByNicknameAndEmailAndRoleAndIdNot(name, email, Role.ROLE_USER, memberId)
                 .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
+
 
         // 이미 친구인 경우
         boolean alreadyFriend = friendRepository.existsByMemberIdAndOpponentId(memberId, opponent.getId());

--- a/src/main/java/com/project/backend/domain/friend/service/query/FriendQueryService.java
+++ b/src/main/java/com/project/backend/domain/friend/service/query/FriendQueryService.java
@@ -9,4 +9,6 @@ public interface FriendQueryService {
     FriendResDTO.FriendRequestListRes getReceivedFriendRequest(Long memberId);
 
     FriendResDTO.FriendListRes getFriend(Long memberId);
+
+    FriendResDTO.FriendListRes searchFriend(Long memberId, String keyword);
 }

--- a/src/main/java/com/project/backend/domain/friend/service/query/FriendQueryServiceImpl.java
+++ b/src/main/java/com/project/backend/domain/friend/service/query/FriendQueryServiceImpl.java
@@ -48,12 +48,20 @@ public class FriendQueryServiceImpl implements FriendQueryService{
     public FriendResDTO.FriendListRes getFriend(Long memberId) {
         // 모든 친구 조회
         List<Friend> friendList = friendRepository.findByMemberId(memberId);
-        // List<Friend> -> List<FriendDetailRes>
-        List<FriendResDTO.FriendDetailRes> detailResList = friendList.stream()
-                .map(FriendConverter::toFriendDetailRes)
-                .toList();
+        // List<Friend> -> FriendListRes
+        return getFriendListRes(friendList);
+    }
 
-        return FriendConverter.toFriendList(detailResList);
+    @Override
+    public FriendResDTO.FriendListRes searchFriend(Long memberId, String keyword) {
+        // 키워드가 없는 경우에는 일반 조회 반환
+        if (keyword == null || keyword.isBlank()) {
+            return getFriend(memberId);
+        }
+        // 내 친구 중에서 검색한 keyword를 포함한 이름을 갖는 친구 조회
+        List<Friend> searchedFriendList = friendRepository.findByMemberIdAndKeyword(memberId, keyword);
+        // List<Friend> -> FriendListRes
+        return getFriendListRes(searchedFriendList);
     }
 
     // id로 멤버 객체를 조회
@@ -78,5 +86,13 @@ public class FriendQueryServiceImpl implements FriendQueryService{
                 .toList();
 
         return FriendRequestConverter.toFriendRequestList(detailResList);
+    }
+
+    private FriendResDTO.FriendListRes getFriendListRes(List<Friend> searchedFriendList) {
+        List<FriendResDTO.FriendDetailRes> detailResList = searchedFriendList.stream()
+                .map(FriendConverter::toFriendDetailRes)
+                .toList();
+
+        return FriendConverter.toFriendList(detailResList);
     }
 }

--- a/src/main/java/com/project/backend/domain/friend/service/query/FriendQueryServiceImpl.java
+++ b/src/main/java/com/project/backend/domain/friend/service/query/FriendQueryServiceImpl.java
@@ -47,7 +47,7 @@ public class FriendQueryServiceImpl implements FriendQueryService{
     @Override
     public FriendResDTO.FriendListRes getFriend(Long memberId) {
         // 모든 친구 조회
-        List<Friend> friendList = friendRepository.findByMemberId(memberId);
+        List<Friend> friendList = friendRepository.findByMemberIdOrderByOpponent_NicknameAsc(memberId);
         // List<Friend> -> FriendListRes
         return getFriendListRes(friendList);
     }

--- a/src/main/java/com/project/backend/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/project/backend/domain/member/repository/MemberRepository.java
@@ -35,6 +35,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findActiveByIdWithAuth(@Param("id") Long id);
 
     // 친구 피요청자의 객체 조회 (역할이 유저이며, 세션 멤버 자기 자신이 아닌)
-    Optional<Member> findByEmailAndRoleAndIdNot(String email, Role role, Long memberId);
+    Optional<Member> findByNicknameAndEmailAndRoleAndIdNot(String name, String email, Role role, Long memberId);
 
 }

--- a/src/main/java/com/project/backend/domain/member/service/MemberService.java
+++ b/src/main/java/com/project/backend/domain/member/service/MemberService.java
@@ -12,6 +12,7 @@ import com.project.backend.domain.member.entity.Member;
 import com.project.backend.domain.member.exception.MemberErrorCode;
 import com.project.backend.domain.member.exception.MemberException;
 import com.project.backend.domain.member.repository.MemberRepository;
+import com.project.backend.domain.reminder.repository.ReminderRepository;
 import com.project.backend.domain.setting.repository.SettingRepository;
 import com.project.backend.domain.suggestion.repository.SuggestionRepository;
 import com.project.backend.domain.todo.repository.TodoRecurrenceExceptionRepository;
@@ -46,6 +47,7 @@ public class MemberService {
     private final SettingRepository settingRepository;
     private final FriendRepository friendRepository;
     private final FriendRequestRepository friendRequestRepository;
+    private final ReminderRepository reminderRepository;
     private final JwtUtil jwtUtil;
     private final CookieUtil cookieUtil;
     private final RedisTemplate<String, Object> redisTemplate;
@@ -97,6 +99,8 @@ public class MemberService {
         // 친구 관련 정보 삭제 (친구 + 친구 요청)
         friendRepository.deleteAllByMemberId(memberId);
         friendRequestRepository.deleteAllByMemberId(memberId);
+        // 리마인더 관련 정보 삭제
+        reminderRepository.deleteAllByMemberId(memberId);
 
         // 4. Member Soft Delete
         member.delete();

--- a/src/main/java/com/project/backend/domain/member/service/MemberService.java
+++ b/src/main/java/com/project/backend/domain/member/service/MemberService.java
@@ -4,6 +4,8 @@ import com.project.backend.domain.event.repository.EventRepository;
 import com.project.backend.domain.event.repository.RecurrenceExceptionRepository;
 import com.project.backend.domain.event.repository.RecurrenceGroupRepository;
 import com.project.backend.domain.auth.dto.response.AuthResDTO;
+import com.project.backend.domain.friend.repository.FriendRepository;
+import com.project.backend.domain.friend.repository.FriendRequestRepository;
 import com.project.backend.domain.member.converter.MemberConverter;
 import com.project.backend.domain.member.dto.response.MemberResDTO;
 import com.project.backend.domain.member.entity.Member;
@@ -42,6 +44,8 @@ public class MemberService {
     private final TodoRepository todoRepository;
     private final SuggestionRepository suggestionRepository;
     private final SettingRepository settingRepository;
+    private final FriendRepository friendRepository;
+    private final FriendRequestRepository friendRequestRepository;
     private final JwtUtil jwtUtil;
     private final CookieUtil cookieUtil;
     private final RedisTemplate<String, Object> redisTemplate;
@@ -90,6 +94,9 @@ public class MemberService {
         todoRepository.deleteAllByMemberId(memberId);
         suggestionRepository.deleteAllByMemberId(memberId);
         settingRepository.deleteByMemberId(memberId);
+        // 친구 관련 정보 삭제 (친구 + 친구 요청)
+        friendRepository.deleteAllByMemberId(memberId);
+        friendRequestRepository.deleteAllByMemberId(memberId);
 
         // 4. Member Soft Delete
         member.delete();

--- a/src/main/java/com/project/backend/domain/reminder/repository/ReminderRepository.java
+++ b/src/main/java/com/project/backend/domain/reminder/repository/ReminderRepository.java
@@ -93,4 +93,8 @@ public interface ReminderRepository extends JpaRepository<Reminder, Long> {
     Optional<Reminder> findByRecurrenceExceptionIdAndTargetType(Long id, TargetType type);
 
     void deleteByTargetIdAndTargetType(Long targetId, TargetType type);
+
+    @Modifying
+    @Query("DELETE FROM Reminder r WHERE r.member.id = :memberId")
+    void deleteAllByMemberId(Long memberId);
 }


### PR DESCRIPTION
# ☝️Issue Number

Close #161 

##  📌 개요

- fdec0f9c5ccd9fadc1f2e5eeaeca1d6001469bfb
  - 오타를 수정했습니다

- 336187b26cc2ac8f2d53037d9927516f1efe9993
  - FriendDocs 생성

- bf37a36a682ae589f67b09edc406828884571f5c
  - Friend 유니크 키 컬럼명 수정

- 8c9e646d7813602e8cc01e95507c3f763fa4ac9e
  - 디자인을 반영하여 친구 추가 시 이름 + 이메일을 입력하도록 변경

- e0fd46881bb7352058612b03897a66d0adc5e807
  - keyword를 사용해 친구 목록에서 친구를 검색하는 API 구현

- f7b699684388e4f205f28f06243d823c234b3a5d
  - 친구 목록 조회 시 친구 이름 오름차순 정렬

- 2bd87d65e1bc9b17f870506409ec771606538e33
  - 회원 탈퇴 시 친구 관련 정보 삭제

- 48e1beef0b351f12322f6f289c63f270196129b9
  - 회원 탈퇴 시 리마인더 관련 정보 삭제

- 55777baab4a75800122bcc92f95b9772fec71c95
  - FriendDocs에 새로 추가된 API 추가

## 🔁 변경 사항

## 📸 스크린샷

## 👀 기타 더 이야기해볼 점
