### PR TITLE
💚ci/cd: MySQL 컨테이너를 RDS로 전환

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,27 +7,10 @@ services:
     env_file:
       - ./.env
     depends_on:
-      mysql:
-        condition: service_healthy
       redis:
         condition: service_healthy
-
-  mysql:
-    container_name: mysql
-    image: mysql:8.0
-    environment:
-      MYSQL_ROOT_PASSWORD: ${DEV_DB_PASSWORD}
-    ports:
-      - "3306:3306"
-    volumes:
-      - ./mysql_data:/var/lib/mysql
-    depends_on:
-      redis:
+      qdrant:
         condition: service_healthy
-    healthcheck:
-      test: ["CMD", "mysqladmin", "ping"]
-      interval: 5s
-      retries: 5
 
   redis:
     container_name: redis


### PR DESCRIPTION
# ☝️Issue Number

Close #168 

##  📌 개요

6c34c4b9f4517a170dc0a7246db6d829045d6525
- MySQL 컨테이너를 RDS로 전환하여 docker-compose.yml 수정

## 🔁 변경 사항
- VPC 구성 (가용영역 2a, 2b)
- calio-server를 calio-public-subnet-a에 임시 생성
  - 나중에 calio-private-subnet으로 옮긴 후 bastion host 사용 가능
- 기존 docker container mysql을 AWS RDS를 사용한 mysql로 변경
- 가용영역 2b는 추후 고가용성 서비스를 위해 사용

## 📸 스크린샷
<img width="1055" height="1491" alt="image" src="https://github.com/user-attachments/assets/a41e78a9-b554-4a03-8fb4-d8575d5a8ef6" />


## 👀 기타 더 이야기해볼 점
- 로드 밸런서
- 다중 AZ RDS
- 시도해보기