### PR TITLE
✨Feat: 임베딩 API 비동기 구현(#170)

### DIFF
--- a/src/main/java/com/project/backend/domain/common/enums/VectorSyncStatus.java
+++ b/src/main/java/com/project/backend/domain/common/enums/VectorSyncStatus.java
@@ -1,0 +1,5 @@
+package com.project.backend.domain.common.enums;
+
+public enum VectorSyncStatus {
+    PENDING, SUCCESS, FAILED
+}

--- a/src/main/java/com/project/backend/domain/event/entity/Event.java
+++ b/src/main/java/com/project/backend/domain/event/entity/Event.java
@@ -1,5 +1,6 @@
 package com.project.backend.domain.event.entity;
 
+import com.project.backend.domain.common.enums.VectorSyncStatus;
 import com.project.backend.domain.event.enums.EventColor;
 import com.project.backend.domain.common.recurrence.enums.RecurrenceFrequency;
 import com.project.backend.global.entity.BaseEntity;
@@ -57,6 +58,11 @@ public class Event extends BaseEntity {
 
     @Column(name = "source_suggestion_id")
     private Long sourceSuggestionId;
+
+    @Builder.Default
+    @Enumerated(EnumType.STRING)
+    @Column(name = "vector_sync_status", nullable = false)
+    private VectorSyncStatus vectorSyncStatus = VectorSyncStatus.PENDING;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false)
@@ -170,5 +176,9 @@ public class Event extends BaseEntity {
     public void updateTime(LocalDateTime startTime, LocalDateTime endTime) {
         this.startTime = startTime;
         this.endTime = endTime;
+    }
+
+    public void updateVectorSyncStatus(VectorSyncStatus status) {
+        this.vectorSyncStatus = status;
     }
 }

--- a/src/main/java/com/project/backend/domain/event/repository/EventRepository.java
+++ b/src/main/java/com/project/backend/domain/event/repository/EventRepository.java
@@ -1,5 +1,6 @@
 package com.project.backend.domain.event.repository;
 
+import com.project.backend.domain.common.enums.VectorSyncStatus;
 import com.project.backend.domain.event.entity.Event;
 import com.project.backend.domain.event.entity.RecurrenceGroup;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -61,4 +62,15 @@ public interface EventRepository extends JpaRepository<Event, Long> {
 
     @Query("SELECT e FROM Event e JOIN FETCH e.member")
     List<Event> findAllWithMember();
+
+    @Query("SELECT e FROM Event e JOIN FETCH e.member WHERE e.id = :id")
+    Optional<Event> findWithMemberById(@Param("id") Long id);
+
+    @Query("SELECT e FROM Event e JOIN FETCH e.member " +
+            "WHERE e.vectorSyncStatus = :failed " +
+            "OR (e.vectorSyncStatus = :pending AND e.createdAt < :cutoff)")
+    List<Event> findSyncRetryTargets(
+            @Param("failed") VectorSyncStatus failed,
+            @Param("pending") VectorSyncStatus pending,
+            @Param("cutoff") LocalDateTime cutoff);
 }

--- a/src/main/java/com/project/backend/domain/event/service/ScheduleVectorSyncService.java
+++ b/src/main/java/com/project/backend/domain/event/service/ScheduleVectorSyncService.java
@@ -1,21 +1,52 @@
 package com.project.backend.domain.event.service;
 
+import com.project.backend.domain.common.enums.VectorSyncStatus;
 import com.project.backend.domain.event.entity.Event;
+import com.project.backend.domain.event.repository.EventRepository;
 import com.project.backend.domain.nlp.client.EmbeddingClient;
 import com.project.backend.global.qdrant.client.QdrantVectorClient;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class ScheduleVectorSyncService {
 
+    private final EventRepository eventRepository;
     private final EmbeddingClient embeddingClient;
     private final QdrantVectorClient qdrantVectorClient;
 
-    public void syncOnCreate(Event event) {
+    @Async("vectorSyncExecutor")
+    @Transactional
+    public void syncOnCreate(Long eventId) {
+        Event event = eventRepository.findWithMemberById(eventId)
+                .orElseThrow(() -> new IllegalStateException("벡터 동기화 대상 Event 없음 - eventId: " + eventId));
+        doUpsertSync(event);
+    }
+
+    @Async("vectorSyncExecutor")
+    @Transactional
+    public void syncOnUpdate(Long eventId) {
+        Event event = eventRepository.findWithMemberById(eventId)
+                .orElseThrow(() -> new IllegalStateException("벡터 동기화 대상 Event 없음 - eventId: " + eventId));
+        doUpsertSync(event);
+    }
+
+    @Async("vectorSyncExecutor")
+    public void syncOnDelete(Long eventId) {
+        try {
+            qdrantVectorClient.delete(eventId);
+            log.debug("Qdrant 삭제 완료 - eventId: {}", eventId);
+        } catch (Exception e) {
+            log.error("Qdrant 삭제 실패 - eventId: {}", eventId, e);
+        }
+    }
+
+    private void doUpsertSync(Event event) {
         try {
             float[] vector = embeddingClient.embed(buildEmbedText(event));
             qdrantVectorClient.upsert(
@@ -27,37 +58,18 @@ public class ScheduleVectorSyncService {
                     event.getRecurrenceGroup() != null,
                     vector
             );
-            log.debug("Qdrant 저장 완료 - eventId: {}", event.getId());
+            event.updateVectorSyncStatus(VectorSyncStatus.SUCCESS);
+            log.debug("Qdrant 동기화 완료 - eventId: {}", event.getId());
         } catch (Exception e) {
-            // Qdrant 실패해도 일정 등록은 성공으로 처리
-            log.error("Qdrant 동기화 실패 (create) - eventId: {}", event.getId(), e);
+            log.error("Qdrant 동기화 실패 - eventId: {}", event.getId(), e);
+            event.updateVectorSyncStatus(VectorSyncStatus.FAILED);
         }
     }
 
-    public void syncOnUpdate(Event event) {
-        // upsert = 있으면 업데이트, 없으면 새로 저장
-        syncOnCreate(event);
-    }
-
-    public void syncOnDelete(Long eventId) {
-        try {
-            qdrantVectorClient.delete(eventId);
-            log.debug("Qdrant 삭제 완료 - eventId: {}", eventId);
-        } catch (Exception e) {
-            log.error("Qdrant 동기화 실패 (delete) - eventId: {}", eventId, e);
-        }
-    }
-
-    // 임베딩할 텍스트 : title + content + location 조합
-    // 풍부할수록 의미 검색 정확도 향상
     private String buildEmbedText(Event event) {
         StringBuilder sb = new StringBuilder(event.getTitle());
-        if (event.getContent() != null) {
-            sb.append(" ").append(event.getContent());
-        }
-        if (event.getLocation() != null) {
-            sb.append(" ").append(event.getLocation());
-        }
+        if (event.getContent() != null) sb.append(" ").append(event.getContent());
+        if (event.getLocation() != null) sb.append(" ").append(event.getLocation());
         return sb.toString();
     }
 }

--- a/src/main/java/com/project/backend/domain/event/service/command/EventCommandServiceImpl.java
+++ b/src/main/java/com/project/backend/domain/event/service/command/EventCommandServiceImpl.java
@@ -40,6 +40,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import java.time.DayOfWeek;
 import java.time.LocalDateTime;
@@ -111,7 +113,7 @@ public class EventCommandServiceImpl implements EventCommandService {
         log.info("event created");
         suggestionInvalidationDispatcher.dispatch(memberId, invalidationPlan);
 
-        scheduleVectorSyncService.syncOnCreate(event);
+        afterCommit(() -> scheduleVectorSyncService.syncOnCreate(event.getId()));
 
         return EventConverter.toCreateRes(event);
     }
@@ -272,7 +274,7 @@ public class EventCommandServiceImpl implements EventCommandService {
             log.info("event deleted");
             suggestionInvalidationDispatcher.dispatch(memberId, invalidationPlan);
 
-            scheduleVectorSyncService.syncOnDelete(eventId);
+            afterCommit(() -> scheduleVectorSyncService.syncOnDelete(eventId));
 
             return;
         }
@@ -928,6 +930,15 @@ public class EventCommandServiceImpl implements EventCommandService {
         );
 
         suggestionInvalidationDispatcher.dispatch(member.getId(), invalidationPlan);
-        scheduleVectorSyncService.syncOnUpdate(event);
+        afterCommit(() -> scheduleVectorSyncService.syncOnUpdate(event.getId()));
+    }
+
+    private void afterCommit(Runnable action) {
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+                action.run();
+            }
+        });
     }
 }

--- a/src/main/java/com/project/backend/domain/todo/entity/Todo.java
+++ b/src/main/java/com/project/backend/domain/todo/entity/Todo.java
@@ -1,5 +1,6 @@
 package com.project.backend.domain.todo.entity;
 
+import com.project.backend.domain.common.enums.VectorSyncStatus;
 import com.project.backend.domain.member.entity.Member;
 import com.project.backend.domain.todo.enums.Priority;
 import com.project.backend.domain.todo.enums.TodoColor;
@@ -55,6 +56,11 @@ public class Todo extends BaseEntity {
     @Column(name = "source_suggestion_id")
     private Long sourceSuggestionId;
 
+    @Builder.Default
+    @Enumerated(EnumType.STRING)
+    @Column(name = "vector_sync_status", nullable = false)
+    private VectorSyncStatus vectorSyncStatus = VectorSyncStatus.PENDING;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
@@ -105,6 +111,10 @@ public class Todo extends BaseEntity {
      */
     public void setTodoRecurrenceGroup(TodoRecurrenceGroup todoRecurrenceGroup) {
         this.todoRecurrenceGroup = todoRecurrenceGroup;
+    }
+
+    public void updateVectorSyncStatus(VectorSyncStatus status) {
+        this.vectorSyncStatus = status;
     }
 
     // ===== 팩토리 메서드 =====

--- a/src/main/java/com/project/backend/domain/todo/repository/TodoRepository.java
+++ b/src/main/java/com/project/backend/domain/todo/repository/TodoRepository.java
@@ -1,5 +1,6 @@
 package com.project.backend.domain.todo.repository;
 
+import com.project.backend.domain.common.enums.VectorSyncStatus;
 import com.project.backend.domain.todo.entity.Todo;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -10,6 +11,7 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 public interface TodoRepository extends JpaRepository<Todo, Long> {
 
@@ -79,4 +81,15 @@ public interface TodoRepository extends JpaRepository<Todo, Long> {
 
     @Query("SELECT t FROM Todo t JOIN FETCH t.member")
     List<Todo> findAllWithMember();
+
+    @Query("SELECT t FROM Todo t JOIN FETCH t.member WHERE t.id = :id")
+    Optional<Todo> findWithMemberById(@Param("id") Long id);
+
+    @Query("SELECT t FROM Todo t JOIN FETCH t.member " +
+            "WHERE t.vectorSyncStatus = :failed " +
+            "OR (t.vectorSyncStatus = :pending AND t.createdAt < :cutoff)")
+    List<Todo> findSyncRetryTargets(
+            @Param("failed") VectorSyncStatus failed,
+            @Param("pending") VectorSyncStatus pending,
+            @Param("cutoff") LocalDateTime cutoff);
 }

--- a/src/main/java/com/project/backend/domain/todo/service/command/TodoCommandServiceImpl.java
+++ b/src/main/java/com/project/backend/domain/todo/service/command/TodoCommandServiceImpl.java
@@ -39,6 +39,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -80,28 +82,28 @@ public class TodoCommandServiceImpl implements TodoCommandService {
 
         // 3. Todo 생성
         Todo todo = TodoConverter.toTodo(reqDTO, member, recurrenceGroup);
-        todo = todoRepository.save(todo);
-        upsertTodoTitleHistory(memberId, todo.getTitle());
-        todoVectorSyncService.syncOnCreate(todo);
-        log.debug("할 일 생성 완료 - todoId: {}", todo.getId());
+        Todo savedTodo = todoRepository.save(todo);
+        upsertTodoTitleHistory(memberId, savedTodo.getTitle());
+        afterCommit(() -> todoVectorSyncService.syncOnCreate(savedTodo.getId()));
+        log.debug("할 일 생성 완료 - todoId: {}", savedTodo.getId());
 
         // 4. 반복 그룹에 Todo 연결
         if (recurrenceGroup != null) {
-            recurrenceGroup.setTodo(todo);
+            recurrenceGroup.setTodo(savedTodo);
         }
 
         // 투두 생성에 따른 리스너 생성 로직 실행
         reminderEventBridge.handlePlanChanged(
-                todo.getId(),
+                savedTodo.getId(),
                 TargetType.TODO,
                 memberId,
-                todo.getTitle(),
+                savedTodo.getTitle(),
                 recurrenceGroup != null,
-                todo.getDueTime() != null ? todo.getStartDate().atTime(todo.getDueTime()) : todo.getStartDate().atStartOfDay(),
+                savedTodo.getDueTime() != null ? savedTodo.getStartDate().atTime(savedTodo.getDueTime()) : savedTodo.getStartDate().atStartOfDay(),
                 ChangeType.CREATED
         );
         // 반복의 유무와 상관없이 동일한 이름 + 메모로 생성된 할 일이 있으면 비활성화
-        TodoSuggestionSnapshot afterSnapshot = todoSuggestionSnapshotFactory.from(todo);
+        TodoSuggestionSnapshot afterSnapshot = todoSuggestionSnapshotFactory.from(savedTodo);
 
         InvalidationPlan invalidationPlan = suggestionInvalidationPlanner.planForCreate(
                 afterSnapshot,
@@ -110,7 +112,7 @@ public class TodoCommandServiceImpl implements TodoCommandService {
 
         suggestionInvalidationDispatcher.dispatch(memberId, invalidationPlan);
 
-        return TodoConverter.toTodoInfo(todo);
+        return TodoConverter.toTodoInfo(savedTodo);
     }
 
     @Override
@@ -128,7 +130,7 @@ public class TodoCommandServiceImpl implements TodoCommandService {
             updateSingleTodo(todo, reqDTO);
             // 수정이 완료되면 한 번 upsert
             upsertTodoTitleHistory(memberId, todo.getTitle());
-            todoVectorSyncService.syncOnUpdate(todo);
+            afterCommit(() -> todoVectorSyncService.syncOnUpdate(todo.getId()));
             // 할 일 생성에 따른 리스너 생성 로직 실행
             reminderEventBridge.handlePlanChanged(
                     todo.getId(),
@@ -202,9 +204,11 @@ public class TodoCommandServiceImpl implements TodoCommandService {
                 afterBase = updateThisAndFollowing(todo, occurrenceDate, reqDTO);
                 returnTodo = afterBase;
                 if (hardDeleteGroup) {
-                    todoVectorSyncService.syncOnDelete(todo.getId());
+                    final Long deletedId = todo.getId();
+                    afterCommit(() -> todoVectorSyncService.syncOnDelete(deletedId));
                 }
-                todoVectorSyncService.syncOnCreate(returnTodo);
+                final Long newTodoId = returnTodo.getId();
+                afterCommit(() -> todoVectorSyncService.syncOnCreate(newTodoId));
             }
         };
 
@@ -244,7 +248,7 @@ public class TodoCommandServiceImpl implements TodoCommandService {
         if (!todo.isRecurring()) {
             suggestionRepository.detachPreviousTodo(memberId, todoId);
             todoRepository.delete(todo);
-            todoVectorSyncService.syncOnDelete(todoId);
+            afterCommit(() -> todoVectorSyncService.syncOnDelete(todoId));
             log.debug("단일 할 일 삭제 완료 - todoId: {}", todoId);
             reminderEventBridge.handleReminderDeleted(
                     null,
@@ -309,7 +313,7 @@ public class TodoCommandServiceImpl implements TodoCommandService {
             case THIS_AND_FOLLOWING -> {
                 deleteThisAndFollowing(todo, occurrenceDate, memberId);
                 if (hardDeleteGroup) {
-                    todoVectorSyncService.syncOnDelete(todoId);
+                    afterCommit(() -> todoVectorSyncService.syncOnDelete(todoId));
                 }
             }
         }
@@ -820,5 +824,14 @@ public class TodoCommandServiceImpl implements TodoCommandService {
         } else {
             history.updateLastUsedAt();
         }
+    }
+
+    private void afterCommit(Runnable action) {
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+                action.run();
+            }
+        });
     }
 }

--- a/src/main/java/com/project/backend/domain/todo/service/command/TodoVectorSyncService.java
+++ b/src/main/java/com/project/backend/domain/todo/service/command/TodoVectorSyncService.java
@@ -1,25 +1,54 @@
 package com.project.backend.domain.todo.service.command;
 
+import com.project.backend.domain.common.enums.VectorSyncStatus;
 import com.project.backend.domain.todo.entity.Todo;
+import com.project.backend.domain.todo.repository.TodoRepository;
 import com.project.backend.domain.nlp.client.EmbeddingClient;
 import com.project.backend.global.qdrant.client.QdrantVectorClient;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class TodoVectorSyncService {
 
-    // Event ID와 충돌 방지를 위한 오프셋
-    // Todo Qdrant point ID = todoId + TODO_ID_OFFSET
     private static final long TODO_ID_OFFSET = 2_000_000_000L;
 
+    private final TodoRepository todoRepository;
     private final EmbeddingClient embeddingClient;
     private final QdrantVectorClient qdrantVectorClient;
 
-    public void syncOnCreate(Todo todo) {
+    @Async("vectorSyncExecutor")
+    @Transactional
+    public void syncOnCreate(Long todoId) {
+        Todo todo = todoRepository.findWithMemberById(todoId)
+                .orElseThrow(() -> new IllegalStateException("벡터 동기화 대상 Todo 없음 - todoId: " + todoId));
+        doUpsertSync(todo);
+    }
+
+    @Async("vectorSyncExecutor")
+    @Transactional
+    public void syncOnUpdate(Long todoId) {
+        Todo todo = todoRepository.findWithMemberById(todoId)
+                .orElseThrow(() -> new IllegalStateException("벡터 동기화 대상 Todo 없음 - todoId: " + todoId));
+        doUpsertSync(todo);
+    }
+
+    @Async("vectorSyncExecutor")
+    public void syncOnDelete(Long todoId) {
+        try {
+            qdrantVectorClient.delete(todoId + TODO_ID_OFFSET);
+            log.debug("Qdrant 삭제 완료 - todoId: {}", todoId);
+        } catch (Exception e) {
+            log.error("Qdrant 삭제 실패 - todoId: {}", todoId, e);
+        }
+    }
+
+    private void doUpsertSync(Todo todo) {
         try {
             float[] vector = embeddingClient.embed(buildEmbedText(todo));
             qdrantVectorClient.upsert(
@@ -31,26 +60,14 @@ public class TodoVectorSyncService {
                     todo.getTodoRecurrenceGroup() != null,
                     vector
             );
-            log.debug("Qdrant 저장 완료 - todoId: {}", todo.getId());
+            todo.updateVectorSyncStatus(VectorSyncStatus.SUCCESS);
+            log.debug("Qdrant 동기화 완료 - todoId: {}", todo.getId());
         } catch (Exception e) {
-            log.error("Qdrant 동기화 실패 (create) - todoId: {}", todo.getId(), e);
+            log.error("Qdrant 동기화 실패 - todoId: {}", todo.getId(), e);
+            todo.updateVectorSyncStatus(VectorSyncStatus.FAILED);
         }
     }
 
-    public void syncOnUpdate(Todo todo) {
-        syncOnCreate(todo);
-    }
-
-    public void syncOnDelete(Long todoId) {
-        try {
-            qdrantVectorClient.delete(todoId + TODO_ID_OFFSET);
-            log.debug("Qdrant 삭제 완료 - todoId: {}", todoId);
-        } catch (Exception e) {
-            log.error("Qdrant 동기화 실패 (delete) - todoId: {}", todoId, e);
-        }
-    }
-
-    // 임베딩할 텍스트: title + memo 조합
     private String buildEmbedText(Todo todo) {
         StringBuilder sb = new StringBuilder(todo.getTitle());
         if (todo.getMemo() != null) {

--- a/src/main/java/com/project/backend/global/config/AsyncConfig.java
+++ b/src/main/java/com/project/backend/global/config/AsyncConfig.java
@@ -1,0 +1,38 @@
+package com.project.backend.global.config;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.AsyncConfigurer;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.Arrays;
+import java.util.concurrent.Executor;
+
+@Slf4j
+@Configuration
+@EnableAsync
+public class AsyncConfig implements AsyncConfigurer {
+
+    @Bean(name = "vectorSyncExecutor")
+    public Executor vectorSyncExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(2);      // 평상시 유지할 스레드 수
+        executor.setMaxPoolSize(5);       // 최대 생성 가능한 스레드 수
+        executor.setQueueCapacity(100);   // 대기 큐 크기
+        executor.setThreadNamePrefix("vector-sync-");  // 스레드 이름 prefix
+        executor.setWaitForTasksToCompleteOnShutdown(true); // 종료 시 실행 중인 작업 완료 대기
+        executor.setAwaitTerminationSeconds(30);            // 최대 30초까지 대기
+        executor.initialize();
+        return executor;
+    }
+
+    @Override
+    public AsyncUncaughtExceptionHandler getAsyncUncaughtExceptionHandler() {
+        return (ex, method, params) ->
+                log.error("[AsyncError] method={}, params={}, message={}",
+                        method.getName(), Arrays.toString(params), ex.getMessage(), ex);
+    }
+}

--- a/src/main/java/com/project/backend/global/scheduler/VectorSyncRetryScheduler.java
+++ b/src/main/java/com/project/backend/global/scheduler/VectorSyncRetryScheduler.java
@@ -1,0 +1,50 @@
+package com.project.backend.global.scheduler;
+
+import com.project.backend.domain.common.enums.VectorSyncStatus;
+import com.project.backend.domain.event.entity.Event;
+import com.project.backend.domain.event.repository.EventRepository;
+import com.project.backend.domain.event.service.ScheduleVectorSyncService;
+import com.project.backend.domain.todo.entity.Todo;
+import com.project.backend.domain.todo.repository.TodoRepository;
+import com.project.backend.domain.todo.service.command.TodoVectorSyncService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class VectorSyncRetryScheduler {
+
+    private static final int PENDING_TIMEOUT_MINUTES = 5;
+
+    private final TodoRepository todoRepository;
+    private final EventRepository eventRepository;
+    private final TodoVectorSyncService todoVectorSyncService;
+    private final ScheduleVectorSyncService scheduleVectorSyncService;
+
+    @Scheduled(fixedDelay = 300_000)
+    public void retryFailedSync() {
+        LocalDateTime cutOff = LocalDateTime.now().minusMinutes(PENDING_TIMEOUT_MINUTES);
+
+        List<Todo> failedTodos = todoRepository.findSyncRetryTargets(VectorSyncStatus.FAILED, VectorSyncStatus.PENDING, cutOff);
+        List<Event> failedEvents = eventRepository.findSyncRetryTargets(VectorSyncStatus.FAILED, VectorSyncStatus.PENDING, cutOff);
+
+        if (failedTodos.isEmpty() && failedEvents.isEmpty()) {
+            return;
+        }
+
+        log.info("[VectorSyncRetry] 재시도 시작 - todos={}, events={}",
+                failedTodos.size(), failedEvents.size());
+
+        failedTodos.forEach(todo -> todoVectorSyncService.syncOnCreate(todo.getId()));
+        failedEvents.forEach(event -> scheduleVectorSyncService.syncOnCreate(event.getId()));
+
+        log.info("[VectorSyncRetry] 재시도 제출 완료");
+    }
+
+}


### PR DESCRIPTION
# ☝️Issue Number

Close #170 

##  📌 개요
https://github.com/2026-Capstone-Project/BackEnd/commit/40814786588c28017385f4d522efdb0471650de4
- 동기화 상태를 표시하기 위한 코드 추가

https://github.com/2026-Capstone-Project/BackEnd/commit/0f19b8afe14553fbae7875386865a3747076c37f
- 비동기 설정을 한 곳에 응집하였습니다.

https://github.com/2026-Capstone-Project/BackEnd/commit/d1932c3209798664430ea766e2a042e6b306be0d
- TodoVectorSyncService를 비동기로 전환하였습니다.

https://github.com/2026-Capstone-Project/BackEnd/commit/a14796fa3d4866d6f620cf5480fbaffd363b5c7c
- ScheduleVectorSyncService를 비동기로 전환하였습니다.

https://github.com/2026-Capstone-Project/BackEnd/commit/69981096d26d7ceaac3f44472f851d3d2b6541df
- 벡터 동기화에 실패했거나 오래 걸리는 작업을 5분마다 자동으로 재시도하는 스케줄러를 생성하였습니다.

## 🔁 변경 사항
Todo와 Event 엔티티에 vector_sync_status 컬럼이 추가되었습니다.

## 📸 스크린샷

### 기존 OpenAI text-embedding-3-small 모델 + 비동기 X
<img width="702" height="515" alt="image" src="https://github.com/user-attachments/assets/cb40940e-6c71-47a6-8fd9-c7e19d288152" />

### Upstage solar-embedding-1-large 모델 + 비동기 X
<img width="682" height="381" alt="image" src="https://github.com/user-attachments/assets/c798c2e1-c065-4c8b-b837-83f0d48b533f" />

### Upstage solar-embedding-1-large 모델 + 비동기 O
<img width="690" height="393" alt="image" src="https://github.com/user-attachments/assets/207056d7-1738-42f7-b11c-7e933ecee212" />



## 👀 기타 더 이야기해볼 점
OpenAI text-embedding-3-small 모델에서 Upstage solar-embedding-1-large 모델로 변경만 했는데 생각보다 응답 속도가 빨라져서 신기했습니다. 찾아보니까 Upstage는 한국 회사여서 지역적인 이유 때문에 응답 속도가 빨랐던 것 같습니다.

그래도 비동기로 하는게 확실히 빨라서 하기 잘했다는 생각...