### PR TITLE
🐛fix: qdrant healthcheck 제거 및 depends_on 조건 변경

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       redis:
         condition: service_healthy
       qdrant:
-        condition: service_healthy
+        condition: service_started
   redis:
     container_name: redis
     image: redis:7.2
@@ -27,12 +27,6 @@ services:
       - "6333:6333"
     volumes:
       - qdrant_data:/qdrant/storage
-    healthcheck:
-      test: ["CMD-SHELL", "wget -qO- http://localhost:6333/readyz || exit 1"]
-      interval: 5s
-      timeout: 5s
-      retries: 10
-      start_period: 15s
 
 volumes:
   qdrant_data:


### PR DESCRIPTION
qdrant 공식 이미지(debian:13-slim 기반)에 curl, wget, bash 등 헬스체크에 필요한 도구가 포함되어 있지 않아 healthcheck가
항상 실패하는 문제 수정

- qdrant 서비스의 healthcheck 블록 제거
- calio의 qdrant depends_on 조건을 service_healthy → service_started로 변경
- qdrant는 Rust 기반으로 기동 속도가 빠르고 Spring Boot 초기화 시간(10~20초) 이내에 준비 완료되므로 실운영상 문제 없음

# ☝️Issue Number

Close #

##  📌 개요

-

## 🔁 변경 사항

## 📸 스크린샷

## 👀 기타 더 이야기해볼 점
