### PR TITLE
💚ci/cd: RDS를 MySQL 컨테이너로 전환

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,10 +7,29 @@ services:
     env_file:
       - ./.env
     depends_on:
+      mysql:
+        condition: service_healthy
       redis:
         condition: service_healthy
       qdrant:
         condition: service_started
+
+  mysql:
+    image: mysql:8.0
+    environment:
+      MYSQL_ROOT_PASSWORD: ${DEV_DB_PASSWORD}
+    ports:
+      - "3306:3306"
+    volumes:
+      - ./mysql_data:/var/lib/mysql
+    depends_on:
+      redis:
+        condition: service_healthy
+    healthcheck:
+      test: [ "CMD", "mysqladmin", "ping" ]
+      interval: 5s
+      retries: 5
+
   redis:
     container_name: redis
     image: redis:7.2
@@ -20,6 +39,7 @@ services:
       test: ["CMD", "redis-cli", "ping"]
       interval: 5s
       retries: 5
+
   qdrant:
     container_name: qdrant
     image: qdrant/qdrant:latest


### PR DESCRIPTION
# ☝️Issue Number

Close #180 

##  📌 개요

- RDS를 MySQL 컨테이너로 전환

## 🔁 변경 사항

- fb460617dd403d83d368529d47d93746f768f764
  - AWS 비용이 많이 나오는 사유로 RDS와 가용 영역별 서브넷을 구현하지 않고 ec2에 컨테이너로 돌리는 방식을 사용

## 📸 스크린샷

## 👀 기타 더 이야기해볼 점
