### PR TITLE
🐛fix: mysql 컨테이너 이름이 고정되지 않았던 오류

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services:
         condition: service_started
 
   mysql:
+    container_name: mysql
     image: mysql:8.0
     environment:
       MYSQL_ROOT_PASSWORD: ${DEV_DB_PASSWORD}


### PR DESCRIPTION
# ☝️Issue Number

Close #180 

##  📌 개요

- 82f620eca7ec03adc500477c64848c72e878e14d
  - mysql 컨테이너 이름을 'mysql'로 고정
## 🔁 변경 사항

## 📸 스크린샷

## 👀 기타 더 이야기해볼 점
