### PR TITLE
Feat/#184 update recurring event sharing

### DIFF
--- a/src/main/java/com/project/backend/domain/event/controller/EventDocs.java
+++ b/src/main/java/com/project/backend/domain/event/controller/EventDocs.java
@@ -709,6 +709,17 @@ public interface EventDocs {
                     - PATCH 요청이므로 값 비교가 아닌 **필드 존재 여부**로 변경 여부를 판단합니다.
                     - 변경 의도가 없는 경우에도 기존 일정 정보를 그대로 반환할 수 있습니다.
                     
+                    - friendIds 필드를 통해 일정 공유 참여자 목록을 수정할 수 있습니다.
+                    - friendIds에는 상대방 memberId가 아니라, 친구 목록 조회 API에서 내려온 Friend 엔티티 ID를 전달해야 합니다.
+                    - friendIds는 전체 교체 방식으로 동작합니다.
+                      - `"friendIds": [3, 7]` → 공유 참여자를 friendId 3, 7에 해당하는 사용자로 변경
+                      - `"friendIds": []` 또는 `"friendIds": null` → 공유 참여자 전체 제거
+                    - 기존 공유 참여자를 유지하려면 현재 공유 대상 friendIds를 그대로 다시 전달해야 합니다.
+                    
+                    ### ⚠️ friendIds PATCH 주의사항
+                    - friendIds는 다른 필드처럼 부분 병합되지 않고, 전달된 목록으로 전체 교체됩니다.
+                    - 기존 참여자를 유지하려면 기존 friendId도 반드시 함께 포함해야 합니다.
+                    - friendIds가 빈 배열이거나 null이면 공유 참여자를 모두 제거합니다.
                     ---
                     ## 📌 occurrenceDate 규칙
                     
@@ -728,15 +739,26 @@ public interface EventDocs {
                     
                     ### ✅ THIS_EVENT
                     - 선택한 occurrenceDate(태생) 회차만 수정합니다.
-                    - RecurrenceException(OVERRIDE)이 생성/갱신됩니다.
-                    - **이 범위에서는 friendIds로 공유 참여자 수정이 불가능합니다.**
+                    - 참여자 목록에 변화가 없는 경우:
+                      - RecurrenceException(OVERRIDE)이 생성/갱신됩니다.
+                    - 참여자 목록에 변화가 있는 경우:
+                      - 기존 반복 occurrence는 RecurrenceException(SKIP) 처리됩니다.
+                      - 수정 요청 내용이 반영된 새로운 단일 Event가 생성됩니다.
+                      - 기존 반복 일정에서 ACCEPTED 상태였고 새 friendIds에도 포함된 사용자는 새 일정에서도 ACCEPTED 상태로 복사됩니다.
+                      - 기존 참여자가 아니었거나 새로 추가된 사용자는 PENDING 상태로 초대됩니다.
+                      - 새 일정에 ACCEPTED 참여자가 1명 이상 있으면 공유 일정으로 처리됩니다.
+                      - 새 일정에 PENDING 참여자만 있거나 참여자가 없으면 아직 공유 확정 상태가 아니므로 isShared=false로 처리됩니다.
                     
                     ### ✅ THIS_AND_FOLLOWING_EVENTS
                     - 선택한 occurrenceDate(태생) 회차와 그 이후를 수정합니다.
                     - 기존 반복 그룹은 occurrenceDate 이전까지만 유지됩니다.
                     - occurrenceDate는 새 반복의 기준점(base)이 됩니다.
                     - 반복 일정을 대상으로 반복 관련 필드를 수정하는 경우 THIS_AND_FOLLOWING_EVENTS를 통해서만 수정 가능합니다.
-                    
+                    - friendIds가 함께 전달되면 새로 생성되는 반복 Event의 공유 참여자 목록도 함께 변경됩니다.
+                    - 기존 반복 일정에서 ACCEPTED 상태였고 새 friendIds에도 포함된 사용자는 새 반복 일정에서도 ACCEPTED 상태로 복사됩니다.
+                    - 기존 참여자가 아니었거나 새로 추가된 사용자는 PENDING 상태로 초대됩니다.
+                    - 새 반복 일정에 ACCEPTED 참여자가 1명 이상 있으면 공유 일정으로 처리됩니다.
+                    - 새 반복 일정에 PENDING 참여자만 있거나 참여자가 없으면 아직 공유 확정 상태가 아니므로 isShared=false로 처리됩니다.
                     ---
                     ## ⏱️ 시간(startTime / endTime) 처리 규칙
                     
@@ -853,6 +875,8 @@ public interface EventDocs {
                                               }
                                             }
                                             """
+
+
                             )
                     }
             )
@@ -1034,6 +1058,116 @@ public interface EventDocs {
                                                       "message": "간격 값 범위가 올바르지 않습니다."
                                                     }
                                                     """
+                                    ),
+                                    @ExampleObject(
+                                            name = "단일 일정 - 공유 참여자 수정",
+                                            description = """
+                                            단일 일정의 공유 참여자 목록을 수정합니다.
+
+                                            ⚠️ friendIds에는 상대방 memberId가 아니라 Friend 엔티티의 id를 전달해야 합니다.
+                                            friendIds는 전체 교체 방식입니다.
+                                            기존 참여자를 유지하려면 기존 friendId도 함께 다시 전달해야 합니다.
+                                            """,
+                                            value = """
+                                            {
+                                              "friendIds": [3, 7]
+                                            }
+                                            """
+                                    ),
+                                    @ExampleObject(
+                                            name = "단일 일정 - 공유 참여자 전체 제거",
+                                            description = """
+                                            단일 일정의 공유 참여자를 모두 제거합니다.
+
+                                            friendIds가 빈 배열이거나 null이면 공유 참여자를 전체 제거합니다.
+                                            """,
+                                            value = """
+                                            {
+                                              "friendIds": []
+                                            }
+                                            """
+                                    ),
+                                    @ExampleObject(
+                                            name = "반복 일정 - 이 일정만 수정 + 참여자 변경",
+                                            description = """
+                                            반복 일정 중 선택한 회차만 수정하면서 공유 참여자 목록도 변경합니다.
+
+                                            처리 방식:
+                                            - 참여자 목록에 변화가 있으면 기존 반복 occurrence는 SKIP 처리됩니다.
+                                            - 수정 내용이 반영된 새로운 단일 Event가 생성됩니다.
+                                            - 기존 ACCEPTED 참여자 중 새 friendIds에도 포함된 사용자는 새 일정에서도 ACCEPTED 상태가 됩니다.
+                                            - 새로 추가된 사용자는 PENDING 상태로 초대됩니다.
+                                            """,
+                                            value = """
+                                            {
+                                              "title": "특별 회의",
+                                              "startTime": "2026-02-06T14:00:00",
+                                              "endTime": "2026-02-06T15:00:00",
+                                              "friendIds": [3, 7]
+                                            }
+                                            """
+                                    ),
+                                    @ExampleObject(
+                                            name = "반복 일정 - 이 일정만 수정 + 참여자 전체 제거",
+                                            description = """
+                                            반복 일정 중 선택한 회차만 수정하면서 공유 참여자를 모두 제거합니다.
+
+                                            처리 방식:
+                                            - 기존 반복 occurrence는 SKIP 처리됩니다.
+                                            - 수정 내용이 반영된 새로운 단일 Event가 생성됩니다.
+                                            - 새 단일 Event에는 EventParticipant가 생성되지 않습니다.
+                                            - 새 단일 Event는 isShared=false 상태가 됩니다.
+                                            """,
+                                            value = """
+                                            {
+                                              "title": "개인 일정으로 변경",
+                                              "friendIds": []
+                                            }
+                                            """
+                                    ),
+                                    @ExampleObject(
+                                            name = "반복 일정 - 이 일정 + 이후 수정 (참여자 변경 포함)",
+                                            description = """
+                                            선택한 회차와 그 이후 반복 일정을 수정하면서 공유 참여자 목록도 함께 변경합니다.
+
+                                            처리 방식:
+                                            - 기존 반복 그룹은 occurrenceDate 이전까지만 유지됩니다.
+                                            - occurrenceDate를 기준으로 새 반복 Event가 생성됩니다.
+                                            - 기존 ACCEPTED 참여자 중 새 friendIds에도 포함된 사용자는 새 반복 일정에서도 ACCEPTED 상태가 됩니다.
+                                            - 새로 추가된 사용자는 PENDING 상태로 초대됩니다.
+                                            """,
+                                            value = """
+                                            {
+                                              "friendIds": [3, 7],
+                                              "recurrenceGroup": {
+                                                "frequency": "WEEKLY",
+                                                "daysOfWeek": ["MONDAY", "THURSDAY"],
+                                                "endType": "NEVER"
+                                              }
+                                            }
+                                            """
+                                    ),
+                                    @ExampleObject(
+                                            name = "반복 일정 - 이 일정 + 이후 수정 (참여자 전체 제거)",
+                                            description = """
+                                            선택한 회차와 그 이후 반복 일정을 수정하면서 공유 참여자를 모두 제거합니다.
+
+                                            처리 방식:
+                                            - 기존 반복 그룹은 occurrenceDate 이전까지만 유지됩니다.
+                                            - occurrenceDate를 기준으로 새 반복 Event가 생성됩니다.
+                                            - 새 반복 Event에는 EventParticipant가 생성되지 않습니다.
+                                            - 새 반복 Event는 isShared=false 상태가 됩니다.
+                                            """,
+                                            value = """
+                                            {
+                                              "friendIds": [],
+                                              "recurrenceGroup": {
+                                                "frequency": "WEEKLY",
+                                                "daysOfWeek": ["THURSDAY"],
+                                                "endType": "NEVER"
+                                              }
+                                            }
+                                            """
                                     )
                             }
                     )
@@ -1051,17 +1185,6 @@ public interface EventDocs {
                                                       "isSuccess": false,
                                                       "code": "EVENT404_1",
                                                       "message": "일정을 찾을 수 없습니다"
-                                                    }
-                                                    """
-                                    ),
-                                    @ExampleObject(
-                                            name = "EVENT404_5",
-                                            summary = "공유 대상으로 전달한 friendIds가 주최자와 친구 관계가 아닌 경우",
-                                            value = """
-                                                    {
-                                                      "isSuccess": false,
-                                                      "code": "EVENT404_5",
-                                                      "message": "주최자와 친구사이가 아닙니다."
                                                     }
                                                     """
                                     )

--- a/src/main/java/com/project/backend/domain/event/exception/EventErrorCode.java
+++ b/src/main/java/com/project/backend/domain/event/exception/EventErrorCode.java
@@ -30,8 +30,6 @@ public enum EventErrorCode implements BaseErrorCode {
                     "반복 필드 수정, 단일 일정 -> 반복 일정으로 수정 시, THIS_AND_FOLLOWING_EVENTS만 가능합니다."),
     EVENT_INVITEE_NOT_FRIEND(HttpStatus.NOT_FOUND, "EVENT404_5", "주최자와 친구사이가 아닙니다."),
     EVENT_SELF_INVITE_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "EVENT400_11", "자기자신은 초대할 수 없습니다."),
-    INVALID_PARTICIPANT_UPDATE_SCOPE(HttpStatus.BAD_REQUEST, "EVENT400_12", "ThisEvent일 때는 공유 불가."),
-
     EVENT_INVITATION_NOT_FOUND(HttpStatus.NOT_FOUND, "EVENT404_6", "해당 일정 공유 초대가 존재하지 않습니다."),
     EVENT_INVITATION_FORBIDDEN(HttpStatus.FORBIDDEN, "EVENT403_1", "해당 일정 공유 초대에 대한 권한이 없습니다"),
 

--- a/src/main/java/com/project/backend/domain/event/service/command/EventCommandServiceImpl.java
+++ b/src/main/java/com/project/backend/domain/event/service/command/EventCommandServiceImpl.java
@@ -219,15 +219,9 @@ public class EventCommandServiceImpl implements EventCommandService {
         switch (scope){
             case THIS_EVENT -> {
                 updateThisEventOnly(req, event, member, occurrenceDate);
-                if (req.friendIds() != null) {
-                    throw new EventException(EventErrorCode.INVALID_PARTICIPANT_UPDATE_SCOPE);
-                }
             }
             case THIS_AND_FOLLOWING_EVENTS ->{
                 afterBase = updateThisAndFutureEvents(req, event, member, startTime, endTime, occurrenceDate);
-                if (req.friendIds() != null) {
-                    syncEventParticipants(afterBase, participantIds);
-                }
             }
             default -> throw new EventException(EventErrorCode.INVALID_UPDATE_SCOPE);
         }
@@ -475,6 +469,14 @@ public class EventCommandServiceImpl implements EventCommandService {
 
         byte[] rgHash = SuggestionKeyUtil.rgHash(rg.getId());
 
+        // 기존 반복 일정에서 실제 참여가 확정된 사용자 목록
+        Set<Long> oldAcceptedParticipantIds =
+                eventParticipantRepository.findSetMemberIdsByEventId(event.getId(),InviteStatus.ACCEPTED);
+
+        // 수정 요청으로 들어온 friendIds를 실제 초대 대상 memberId Set으로 변환
+        Set<Long> requestedParticipantIds = resolveRequestedParticipantIds(req.friendIds(), member.getId());
+
+
         // 만약 이미 수정된 일정을 또 수정하는 경우
         Optional<RecurrenceException> re = recurrenceExRepository
                 .findByRecurrenceGroupIdAndExceptionDateAndExceptionType(
@@ -484,87 +486,28 @@ public class EventCommandServiceImpl implements EventCommandService {
                 );
 
         if (re.isPresent()) {
-
-            // 기존 반복 일정에서 실제 참여가 확정된 사용자 목록
-            // PENDING은 아직 참여자가 아니므로 비교 대상에서 제외한다.
-            Set<Long> oldAcceptedParticipantIds =
-                    eventParticipantRepository.findSetMemberIdsByEventId(
-                            event.getId(),
-                            InviteStatus.ACCEPTED
-                    );
-
-            // 수정 요청으로 들어온 friendIds를 실제 초대 대상 memberId Set으로 변환
-            Set<Long> requestedParticipantIds =
-                    resolveRequestedParticipantIds(req.friendIds(), member.getId());
-
             // 기존 확정 참여자 목록과 수정 요청 참여자 목록이 다르면
-            // 공유 구성 변경으로 보고 반복예외가 아닌 새 단일 Event로 분리 생성한다.
+            // 공유 참여자 구성 변경으로 보고 반복예외가 아닌 새 단일 Event로 분리 생성한다.
             if (!oldAcceptedParticipantIds.equals(requestedParticipantIds)) {
-                LocalDateTime newStartTime = req.startTime() != null
-                        ? req.startTime()
-                        : occurrenceDate;
+               detachOccurrenceAsSingleEventIfParticipantsChanged(req, event, member, occurrenceDate,
+                                oldAcceptedParticipantIds, requestedParticipantIds);
 
-                LocalDateTime newEndTime = req.endTime() != null
-                        ? req.endTime()
-                        : occurrenceDate.plusMinutes(event.getDurationMinutes());
+                // 기존 수정된 일정 OVERRIDE -> SKIP 상태로 변경 (더 이상 필요 없기 때문)
+                re.get().updateExceptionTypeToSKIP();
 
-                EventSpec eventSpec = EventConverter.from(
-                        req,
-                        event,
-                        newStartTime,
-                        newEndTime
-                );
-
-                Event newEvent = createEvent(eventSpec, member, null);
-
-                createParticipantsForDetachedEvent(
-                        newEvent,
-                        member,
-                        oldAcceptedParticipantIds,
-                        requestedParticipantIds
-                );
-
-                // 작성자 리마인더는 항상 생성
-                reminderEventBridge.handlePlanChanged(
-                        newEvent.getId(),
-                        TargetType.EVENT,
-                        member.getId(),
-                        newEvent.getTitle(),
-                        false,
-                        newEvent.getStartTime(),
-                        ChangeType.CREATED
-                );
-
-                // 기존 ACCEPTED였고 새 요청에도 포함된 사용자만 리마인더 생성
-                List<Long> copiedAcceptedParticipantIds = requestedParticipantIds.stream()
-                        .filter(oldAcceptedParticipantIds::contains)
-                        .toList();
-
-                for (Long participantId : copiedAcceptedParticipantIds) {
-                    reminderEventBridge.handlePlanChanged(
-                            newEvent.getId(),
-                            TargetType.EVENT,
-                            participantId,
-                            newEvent.getTitle(),
-                            false,
-                            newEvent.getStartTime(),
-                            ChangeType.CREATED
-                    );
-                }
-
-            } else {
-                RecurrenceException ex = re.get();
-                updateRecurrenceException(req, ex);
-                reminderEventBridge.handleExceptionChanged(
-                        ex.getId(),
-                        event.getId(),
-                        TargetType.EVENT,
-                        member.getId(),
-                        ex.getTitle() != null ? ex.getTitle() : event.getTitle(),
-                        ex.getStartTime() != null ? ex.getStartTime() : ex.getExceptionDate(),
-                        ExceptionChangeType.UPDATE_THIS_AGAIN
-                );
+                return;
             }
+            RecurrenceException ex = re.get();
+            updateRecurrenceException(req, ex);
+            reminderEventBridge.handleExceptionChanged(
+                    ex.getId(),
+                    event.getId(),
+                    TargetType.EVENT,
+                    member.getId(),
+                    ex.getTitle() != null ? ex.getTitle() : event.getTitle(),
+                    ex.getStartTime() != null ? ex.getStartTime() : ex.getExceptionDate(),
+                    ExceptionChangeType.UPDATE_THIS_AGAIN
+            );
 
             log.info("exception updated");
             InvalidationPlan invalidationPlan = suggestionInvalidationPlanner.planForSingleTarget(
@@ -581,15 +524,27 @@ public class EventCommandServiceImpl implements EventCommandService {
         recurrenceExRepository.save(ex);
         rg.addExceptionDate(ex); // 해당 event가 속했던 반복 객체에 예외 날짜 추가
 
-        // 해당 일정만 수정했을 때 리스너 수정 로직 실행
-        reminderEventBridge.handleExceptionChanged(
-                ex.getId(),
-                event.getId(),
-                TargetType.EVENT,
-                member.getId(),
-                ex.getTitle() != null ? ex.getTitle() : event.getTitle(),
-                ex.getStartTime() != null ? ex.getStartTime() : ex.getExceptionDate(),
-                ExceptionChangeType.UPDATED_THIS);
+        // 기존 확정 참여자 목록과 수정 요청 참여자 목록이 다르면
+        // 공유 구성 변경으로 보고 반복예외가 아닌 새 단일 Event로 분리 생성한다.
+        if (!oldAcceptedParticipantIds.equals(requestedParticipantIds)) {
+            detachOccurrenceAsSingleEventIfParticipantsChanged(req, event, member, occurrenceDate,
+                            oldAcceptedParticipantIds, requestedParticipantIds);
+
+            // 기존 수정된 일정 OVERRIDE -> SKIP 상태로 변경 (더 이상 필요 없기 때문)
+            ex.updateExceptionTypeToSKIP();
+
+            return;
+        } else {
+            // 해당 일정만 수정했을 때 리스너 수정 로직 실행
+            reminderEventBridge.handleExceptionChanged(
+                    ex.getId(),
+                    event.getId(),
+                    TargetType.EVENT,
+                    member.getId(),
+                    ex.getTitle() != null ? ex.getTitle() : event.getTitle(),
+                    ex.getStartTime() != null ? ex.getStartTime() : ex.getExceptionDate(),
+                    ExceptionChangeType.UPDATED_THIS);
+        }
 
         log.info("exception updated");
         InvalidationPlan invalidationPlan = suggestionInvalidationPlanner.planForSingleTarget(
@@ -1177,6 +1132,69 @@ public class EventCommandServiceImpl implements EventCommandService {
         return new HashSet<>(savedIds).equals(new HashSet<>(memberIdsInFriends));
     }
 
+
+    private void detachOccurrenceAsSingleEventIfParticipantsChanged(
+            EventReqDTO.UpdateReq req,
+            Event event,
+            Member member,
+            LocalDateTime occurrenceDate,
+            Set<Long> oldAcceptedParticipantIds,
+            Set<Long> requestedParticipantIds
+    ) {
+
+        LocalDateTime newStartTime = req.startTime() != null
+                ? req.startTime()
+                : occurrenceDate;
+
+        LocalDateTime newEndTime = req.endTime() != null
+                ? req.endTime()
+                : occurrenceDate.plusMinutes(event.getDurationMinutes());
+
+        EventSpec eventSpec = EventConverter.from(
+                req,
+                event,
+                newStartTime,
+                newEndTime
+        );
+
+        Event newEvent = createEvent(eventSpec, member, null);
+
+        createParticipantsForDetachedEvent(
+                newEvent,
+                member,
+                oldAcceptedParticipantIds,
+                requestedParticipantIds
+        );
+
+        // 작성자 리마인더는 항상 생성
+        reminderEventBridge.handlePlanChanged(
+                newEvent.getId(),
+                TargetType.EVENT,
+                member.getId(),
+                newEvent.getTitle(),
+                false,
+                newEvent.getStartTime(),
+                ChangeType.CREATED
+        );
+
+        // 기존 ACCEPTED였고 새 요청에도 포함된 사용자만 리마인더 생성
+        List<Long> copiedAcceptedParticipantIds = requestedParticipantIds.stream()
+                .filter(oldAcceptedParticipantIds::contains)
+                .toList();
+
+        for (Long participantId : copiedAcceptedParticipantIds) {
+            reminderEventBridge.handlePlanChanged(
+                    newEvent.getId(),
+                    TargetType.EVENT,
+                    participantId,
+                    newEvent.getTitle(),
+                    false,
+                    newEvent.getStartTime(),
+                    ChangeType.CREATED
+            );
+        }
+    }
+
     /**
      * 반복 일정의 특정 occurrence를 새 단일 일정으로 분리할 때,
      * 수정 요청의 참여자 목록을 기준으로 새 EventParticipant를 생성한다.
@@ -1285,5 +1303,17 @@ public class EventCommandServiceImpl implements EventCommandService {
         }
 
         return participantIds;
+    }
+
+    private boolean hasParticipantCompositionChanged(Event event, EventReqDTO.UpdateReq req, Long memberId) {
+        // 기존 반복 일정에서 실제 참여가 확정된 사용자 목록
+        Set<Long> oldAcceptedParticipantIds =
+                eventParticipantRepository.findSetMemberIdsByEventId(event.getId(),InviteStatus.ACCEPTED);
+
+        // 수정 요청으로 들어온 friendIds를 실제 초대 대상 memberId Set으로 변환
+        Set<Long> requestedParticipantIds = resolveRequestedParticipantIds(req.friendIds(), memberId);
+
+
+        return oldAcceptedParticipantIds.equals(requestedParticipantIds);
     }
 }

--- a/src/main/java/com/project/backend/domain/event/service/command/EventCommandServiceImpl.java
+++ b/src/main/java/com/project/backend/domain/event/service/command/EventCommandServiceImpl.java
@@ -607,16 +607,33 @@ public class EventCommandServiceImpl implements EventCommandService {
             LocalDateTime end,
             LocalDateTime occurrenceDate
     ) {
+        // 기존 반복 일정에서 실제 참여가 확정된 사용자 목록
+        Set<Long> oldAcceptedParticipantIds =
+                eventParticipantRepository.findSetMemberIdsByEventId(
+                        event.getId(),
+                        InviteStatus.ACCEPTED
+                );
+
+        // 수정 요청으로 들어온 friendIds를 실제 초대 대상 memberId Set으로 변환
+        Set<Long> requestedParticipantIds =
+                resolveRequestedParticipantIds(req.friendIds(), member.getId());
+
         RecurrenceGroup rg = event.getRecurrenceGroup();
 
         // 새 반복그룹을 가진 새 이벤트 생성
         Event newEvent = createEventWithNewRecurrenceGroup(req, event, member, start, end);
+
+        // 새 일정에 대한 참여자와 리마인더 처리
+        applyParticipantsAndRemindersForNewEvent(
+                member, oldAcceptedParticipantIds, requestedParticipantIds, newEvent, true);
 
         // 수정하려는 날짜 포함한 이후 일정들에 대한 반복예외 객체 모두 삭제
         recurrenceExRepository.deleteByRecurrenceGroupIdAndOccurrenceDate(rg.getId(), occurrenceDate);
 
         // 원본 일정에 대한 수정이면 기존 일정 + 반복 삭제
         if (Objects.equals(event.getStartTime(), occurrenceDate)) {
+            // 기존 Event를 참조하는 EventParticipant 먼저 삭제
+            eventParticipantRepository.deleteAllByEventId(event.getId());
             eventRepository.delete(event);
             recurrenceGroupRepository.delete(event.getRecurrenceGroup());
             reminderEventBridge.handleReminderDeleted(
@@ -642,16 +659,16 @@ public class EventCommandServiceImpl implements EventCommandService {
             );
         }
 
-        // 새 일정 생성에 대한 리마인더 발생
-        reminderEventBridge.handlePlanChanged(
-                newEvent.getId(),
-                TargetType.EVENT,
-                member.getId(),
-                newEvent.getTitle(),
-                true,
-                newEvent.getStartTime(),
-                ChangeType.CREATED
-        );
+//        // 새 일정 생성에 대한 리마인더 발생
+//        reminderEventBridge.handlePlanChanged(
+//                newEvent.getId(),
+//                TargetType.EVENT,
+//                member.getId(),
+//                newEvent.getTitle(),
+//                true,
+//                newEvent.getStartTime(),
+//                ChangeType.CREATED
+//        );
         return newEvent;
     }
 
@@ -1159,6 +1176,17 @@ public class EventCommandServiceImpl implements EventCommandService {
 
         Event newEvent = createEvent(eventSpec, member, null);
 
+        applyParticipantsAndRemindersForNewEvent(
+                member, oldAcceptedParticipantIds, requestedParticipantIds, newEvent, false);
+    }
+
+    private void applyParticipantsAndRemindersForNewEvent(
+            Member member,
+            Set<Long> oldAcceptedParticipantIds,
+            Set<Long> requestedParticipantIds,
+            Event newEvent,
+            boolean isRecurring
+    ) {
         createParticipantsForDetachedEvent(
                 newEvent,
                 member,
@@ -1172,7 +1200,7 @@ public class EventCommandServiceImpl implements EventCommandService {
                 TargetType.EVENT,
                 member.getId(),
                 newEvent.getTitle(),
-                false,
+                isRecurring,
                 newEvent.getStartTime(),
                 ChangeType.CREATED
         );
@@ -1188,7 +1216,7 @@ public class EventCommandServiceImpl implements EventCommandService {
                     TargetType.EVENT,
                     participantId,
                     newEvent.getTitle(),
-                    false,
+                    isRecurring,
                     newEvent.getStartTime(),
                     ChangeType.CREATED
             );

--- a/src/main/java/com/project/backend/domain/event/validator/EventValidator.java
+++ b/src/main/java/com/project/backend/domain/event/validator/EventValidator.java
@@ -108,7 +108,7 @@ public class EventValidator {
         }
 
         // 반복 일정에 특정 날짜를 기준으로 반복 필드를 수정할 때, THIS_AND_FOLLOWING_EVENTS가 아닌경우
-        if (req != null && scope != RecurrenceUpdateScope.THIS_AND_FOLLOWING_EVENTS) {
+        if (isRecurring && req != null && scope != RecurrenceUpdateScope.THIS_AND_FOLLOWING_EVENTS) {
             throw new EventException(EventErrorCode.THIS_AND_FOLLOWING_EVENTS_ONLY);
         }
     }

--- a/src/main/java/com/project/backend/domain/friend/repository/FriendRepository.java
+++ b/src/main/java/com/project/backend/domain/friend/repository/FriendRepository.java
@@ -55,7 +55,7 @@ public interface FriendRepository extends JpaRepository<Friend, Long> {
     @Query("""
     select f.opponent.id
     from Friend f
-    where f.opponent.id in :friendIds
+    where f.id in :friendIds
       and f.member.id = :memberId
 """)
     List<Long> findOpponentMemberIdsByFriendIdsAndMemberId(@Param("friendIds") List<Long> friendIds,

--- a/src/main/java/com/project/backend/domain/reminder/repository/ReminderRepository.java
+++ b/src/main/java/com/project/backend/domain/reminder/repository/ReminderRepository.java
@@ -53,7 +53,7 @@ public interface ReminderRepository extends JpaRepository<Reminder, Long> {
             "WHERE r.targetId = :targetId " +
             "AND r.targetType = :type" +
             " AND r.role = :role")
-    Optional<Reminder> findByIdAndTypeAndRole(
+    List<Reminder> findByIdAndTypeAndRole(
             @Param("targetId") Long targetId,
             @Param("type") TargetType type,
             @Param("role") ReminderRole role

--- a/src/main/java/com/project/backend/domain/reminder/service/command/ReminderCommandServiceImpl.java
+++ b/src/main/java/com/project/backend/domain/reminder/service/command/ReminderCommandServiceImpl.java
@@ -161,15 +161,17 @@ public class ReminderCommandServiceImpl implements ReminderCommandService {
 
     @Override
     public void deleteReminderOfThisAndFollowings(Long targetId, TargetType targetType, LocalDateTime occurrenceTime) {
-        Optional<Reminder> reminder = reminderRepository.findByIdAndTypeAndRole(
+        List<Reminder> reminders = reminderRepository.findByIdAndTypeAndRole(
                 targetId, targetType, ReminderRole.BASE);
 
-        if (reminder.isEmpty()) return;
+        if (reminders.isEmpty()) return;
 
-        Reminder re = reminder.get();
+        Reminder re = reminders.getFirst();
         // 원본 일정에 대한 리마인더의 발생 시간이 수정을 통해 생성된 일정의 startTime과 동일하거나 이후라면 원본 일정에 대한 리마인더 삭제
         if (!re.getOccurrenceTime().isBefore(occurrenceTime)) {
-            reminderRepository.deleteById(re.getId());
+            for (Reminder reminder : reminders) {
+                reminderRepository.deleteById(reminder.getId());
+            }
         }
 
         // THIS_AND_FOLLOWING: 기준 occurrenceTime(포함) 이후에 발생하는 리마인더만 삭제한다.

--- a/src/main/java/com/project/backend/domain/todo/service/command/TodoCommandServiceImpl.java
+++ b/src/main/java/com/project/backend/domain/todo/service/command/TodoCommandServiceImpl.java
@@ -127,20 +127,24 @@ public class TodoCommandServiceImpl implements TodoCommandService {
 
         // 단일 할 일인 경우
         if (!todo.isRecurring()) {
-            updateSingleTodo(todo, reqDTO);
+            if (reqDTO.recurrenceGroup() != null) {
+                // 단일 → 반복 변환
+                handleSingleToRecurringTodo(todo, reqDTO, memberId);
+            } else {
+                updateSingleTodo(todo, reqDTO);
+                reminderEventBridge.handlePlanChanged(
+                        todo.getId(),
+                        TargetType.TODO,
+                        memberId,
+                        todo.getTitle(),
+                        false,
+                        todo.getDueTime() != null ? todo.getStartDate().atTime(todo.getDueTime()) : todo.getStartDate().atStartOfDay(),
+                        ChangeType.UPDATE_SINGLE
+                );
+            }
             // 수정이 완료되면 한 번 upsert
             upsertTodoTitleHistory(memberId, todo.getTitle());
             afterCommit(() -> todoVectorSyncService.syncOnUpdate(todo.getId()));
-            // 할 일 생성에 따른 리스너 생성 로직 실행
-            reminderEventBridge.handlePlanChanged(
-                    todo.getId(),
-                    TargetType.TODO,
-                    memberId,
-                    todo.getTitle(),
-                    false,
-                    todo.getDueTime() != null ? todo.getStartDate().atTime(todo.getDueTime()) : todo.getStartDate().atStartOfDay(),
-                    ChangeType.UPDATE_SINGLE
-            );
 
             TodoSuggestionSnapshot afterSnapshot = todoSuggestionSnapshotFactory.from(todo);
 
@@ -420,6 +424,30 @@ public class TodoCommandServiceImpl implements TodoCommandService {
     /**
      * 단일 할 일 수정
      */
+    private void handleSingleToRecurringTodo(Todo todo, TodoReqDTO.UpdateTodo reqDTO, Long memberId) {
+        updateSingleTodo(todo, reqDTO);
+
+        Member member = todo.getMember();
+        TodoRecurrenceGroup rg = TodoConverter.toTodoRecurrenceGroup(reqDTO.recurrenceGroup(), member);
+        rg = todoRecurrenceGroupRepository.save(rg);
+        todo.setTodoRecurrenceGroup(rg);
+        rg.setTodo(todo);
+
+        LocalDateTime startTime = todo.getDueTime() != null
+                ? todo.getStartDate().atTime(todo.getDueTime())
+                : todo.getStartDate().atStartOfDay();
+
+        reminderEventBridge.handlePlanChanged(
+                todo.getId(),
+                TargetType.TODO,
+                memberId,
+                todo.getTitle(),
+                true,
+                startTime,
+                ChangeType.UPDATE_ADD_RECURRENCE
+        );
+    }
+
     private void updateSingleTodo(Todo todo, TodoReqDTO.UpdateTodo reqDTO) {
         todo.update(
                 reqDTO.title(),


### PR DESCRIPTION
# ☝️Issue Number

Close #184 

## 📌 개요

이번 PR에서는 반복 일정 수정 시 공유 참여자 목록이 함께 변경되는 경우의 처리 로직과 updateEvent API 문서를 수정했습니다.

대상 커밋

- 69ddfcaf586dd677e693dac15a4eb2648cbf61aa
  - 반복일정 `THIS_EVENT` 수정 시 참여자 목록이 변경된 경우 새 일정 생성 및 리마인더 생성 로직 에러 처리

- cc316492e481f31f524fe5985a675a382a96ca51
  - `THIS_AND_FOLLOWING_EVENTS` 수정 시 일정 참여자 및 리마인더 처리 로직 구현

- 92f9fae8294bf195dc0874baa68ab0564e1d85f2
  - updateEvent API docs 내용 수정

## 🔁 변경 사항

### 1. 반복 일정 `THIS_EVENT` 수정 시 참여자 변경 처리

- 반복 일정 중 특정 날짜만 수정할 때 참여자 목록이 변경되는 경우, 기존 반복 일정의 해당 회차를 그대로 수정하지 않고 새로운 단일 일정으로 분리 생성하도록 처리했습니다.
- 기존 반복 일정에서 실제 참여가 확정된 `ACCEPTED` 참여자는 새 일정에서도 `ACCEPTED` 상태로 복사됩니다.
- 새롭게 추가된 참여자는 `PENDING` 상태로 초대됩니다.
- 기존 참여자였지만 수정 요청의 `friendIds`에서 제외된 사용자는 새 일정의 참여자로 생성되지 않습니다.
- 기존 반복 occurrence는 더 이상 노출되지 않도록 `RecurrenceException`을 `SKIP` 상태로 처리합니다.
- 새로 생성된 일정에 대해 작성자 리마인더를 생성하고, 기존 `ACCEPTED` 참여자 중 새 일정에도 유지되는 사용자에게만 리마인더를 생성하도록 처리했습니다.

### 2. 반복 일정 `THIS_AND_FOLLOWING_EVENTS` 수정 시 참여자 처리 추가

- 반복 일정의 원본 일정 또는 특정 회차 이후를 수정할 때, 새로 생성되는 반복 일정에 참여자 목록이 반영되도록 처리했습니다.
- 기존 `ACCEPTED` 참여자 중 수정 요청에도 포함된 사용자는 새 반복 일정에서도 `ACCEPTED` 상태로 복사됩니다.
- 새롭게 추가된 사용자는 `PENDING` 상태로 초대됩니다.
- 새 반복 일정에 대해 작성자 리마인더를 생성하고, 기존 `ACCEPTED` 참여자 중 유지되는 사용자에게만 리마인더를 생성하도록 처리했습니다.
- 기존 반복 원본 Event를 삭제하는 경우 FK 제약 오류가 발생하지 않도록 기존 EventParticipant 삭제 흐름을 함께 고려했습니다.

### 3. updateEvent API 문서 수정

- `updateEvent` 요청 바디에 `friendIds` 필드가 추가되었음을 문서화했습니다.
- `friendIds`는 상대방 `memberId`가 아니라 친구 목록 조회 API에서 내려온 `Friend.id`를 전달해야 한다는 내용을 명시했습니다.
- `friendIds`를 통해 일정 수정 시 공유 참여자 목록을 변경할 수 있음을 추가했습니다.
- 반복 일정 수정 시 참여자 목록이 변경되는 경우의 처리 흐름을 문서에 반영했습니다.
  - `THIS_EVENT`: 해당 회차는 `SKIP` 처리되고, 새 단일 일정이 생성됨
  - `THIS_AND_FOLLOWING_EVENTS`: 기존 반복 그룹은 이전 회차까지만 유지되고, 새 반복 일정이 생성됨
- `ACCEPTED`, `PENDING`, `isShared` 처리 기준을 문서에 추가했습니다.

## 📸 스크린샷

없음

## 👀 기타 더 이야기해볼 점