### PR TITLE
Feat/#194 event detail friendid

### DIFF
--- a/src/main/java/com/project/backend/domain/event/converter/EventConverter.java
+++ b/src/main/java/com/project/backend/domain/event/converter/EventConverter.java
@@ -18,6 +18,7 @@ import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 
 @Slf4j
@@ -91,7 +92,9 @@ public class EventConverter {
     public static EventResDTO.DetailRes toDetailRes(
             Event event,
             LocalDateTime occurrenceDate,
-            List<EventParticipant> participants
+            List<EventParticipant> participants,
+            Boolean isOwner,
+            Map<Long, Long> friendIdByMemberId
     ) {
         return EventResDTO.DetailRes.builder()
                 .id(event.getId())
@@ -106,7 +109,8 @@ public class EventConverter {
                 .color(event.getColor())
                 .isShared(event.getIsShared())
                 .recurrenceGroup(RecurrenceGroupConverter.toDetailRes(event.getRecurrenceGroup()))
-                .eventParticipantInfo(getEventParticipantInfos(event.getMember(), participants))
+                .isOwner(isOwner)
+                .eventParticipantInfo(getEventParticipantInfos(event.getMember(), isOwner, participants, friendIdByMemberId))
                 .build();
     }
 
@@ -114,7 +118,9 @@ public class EventConverter {
             Event event,
             RecurrenceException ex,
             LocalDateTime occurrenceDate,
-            List<EventParticipant> participants
+            List<EventParticipant> participants,
+            Boolean isOwner,
+            Map<Long, Long> friendIdByMemberId
     ) {
         return EventResDTO.DetailRes.builder()
                 .id(event.getId())
@@ -131,14 +137,17 @@ public class EventConverter {
                 .recurrenceGroup(
                         RecurrenceGroupConverter.toDetailRes(ex.getRecurrenceGroup())
                 )
-                .eventParticipantInfo(getEventParticipantInfos(event.getMember(), participants))
+                .isOwner(isOwner)
+                .eventParticipantInfo(getEventParticipantInfos(event.getMember(), isOwner, participants, friendIdByMemberId))
                 .build();
     }
 
     // TODO : 오버 로딩 임시조치
     public static EventResDTO.DetailRes toDetailRes(
             Event event,
-            List<EventParticipant> participants
+            List<EventParticipant> participants,
+            Boolean isOwner,
+            Map<Long, Long> friendIdByMemberId
     ) {
         return EventResDTO.DetailRes.builder()
                 .id(event.getId())
@@ -157,7 +166,8 @@ public class EventConverter {
                 .recurrenceGroup(event.getRecurrenceGroup() != null
                         ? RecurrenceGroupConverter.toDetailRes(event.getRecurrenceGroup())
                         : null)
-                .eventParticipantInfo(getEventParticipantInfos(event.getMember(), participants))
+                .isOwner(isOwner)
+                .eventParticipantInfo(getEventParticipantInfos(event.getMember(), isOwner, participants, friendIdByMemberId))
                 .build();
     }
 
@@ -168,7 +178,9 @@ public class EventConverter {
             Event event,
             LocalDateTime start,
             LocalDateTime end,
-            List<EventParticipant> participants
+            List<EventParticipant> participants,
+            Boolean isOwner,
+            Map<Long, Long> friendIdByMemberId
     ) {
         return EventResDTO.DetailRes.builder()
                 .id(event.getId())
@@ -184,7 +196,8 @@ public class EventConverter {
                 .color(event.getColor())
                 .isShared(event.getIsShared())
                 .recurrenceGroup(RecurrenceGroupConverter.toDetailRes(event.getRecurrenceGroup()))
-                .eventParticipantInfo(getEventParticipantInfos(event.getMember(), participants))
+                .isOwner(isOwner)
+                .eventParticipantInfo(getEventParticipantInfos(event.getMember(), isOwner, participants, friendIdByMemberId))
                 .build();
     }
 
@@ -192,7 +205,9 @@ public class EventConverter {
     public static EventResDTO.DetailRes toDetailRes(
             RecurrenceException ex,
             Event event,
-            List<EventParticipant> participants
+            List<EventParticipant> participants,
+            Boolean isOwner,
+            Map<Long, Long> friendIdByMemberId
     ) {
         return EventResDTO.DetailRes.builder()
                 .id(event.getId())
@@ -210,7 +225,8 @@ public class EventConverter {
                 .recurrenceGroup(
                         RecurrenceGroupConverter.toDetailRes(ex.getRecurrenceGroup())
                 )
-                .eventParticipantInfo(getEventParticipantInfos(event.getMember(), participants))
+                .isOwner(isOwner)
+                .eventParticipantInfo(getEventParticipantInfos(event.getMember(), isOwner, participants, friendIdByMemberId))
                 .build();
     }
 
@@ -243,30 +259,57 @@ public class EventConverter {
         return end;
     }
 
+//    private static List<EventResDTO.EventParticipantInfo> getEventParticipantInfos(
+//            Member owner,
+//            List<EventParticipant> participants
+//    ) {
+//        List<EventResDTO.EventParticipantInfo> participantInfos = new ArrayList<>();
+//
+//        // 관리자 정보
+////        participantInfos.add(toOwnerEventParticipantInfo(owner));
+//
+//        // 피공유자 정보
+//        participantInfos.addAll(
+//                participants.stream()
+//                        .map(EventConverter::toEventParticipantInfo)
+//                        .toList()
+//        );
+//
+//        return participantInfos;
+//    }
+
     private static List<EventResDTO.EventParticipantInfo> getEventParticipantInfos(
             Member owner,
-            List<EventParticipant> participants
+            Boolean isOwner,
+            List<EventParticipant> participants,
+            Map<Long, Long> friendIdByMemberId
     ) {
         List<EventResDTO.EventParticipantInfo> participantInfos = new ArrayList<>();
 
-        // 관리자 정보
-//        participantInfos.add(toOwnerEventParticipantInfo(owner));
+        // 관리자가 아니면 관리자 정보를 포함
+//        if (!isOwner) {
+//            participantInfos.add(toOwnerEventParticipantInfo(owner));
+//        }
 
-        // 피공유자 정보
         participantInfos.addAll(
                 participants.stream()
-                        .map(EventConverter::toEventParticipantInfo)
+                        .map(participant -> toEventParticipantInfo(participant, friendIdByMemberId))
                         .toList()
         );
 
         return participantInfos;
     }
 
-    private static EventResDTO.EventParticipantInfo toEventParticipantInfo(EventParticipant eventParticipant) {
+    private static EventResDTO.EventParticipantInfo toEventParticipantInfo(
+            EventParticipant eventParticipant,
+            Map<Long, Long> friendIdByMemberId
+    ) {
         Member member = eventParticipant.getMember();
 
         return EventResDTO.EventParticipantInfo.builder()
                 .eventParticipantId(eventParticipant.getId())
+                .status(eventParticipant.getStatus())
+                .friendId(friendIdByMemberId.get(member.getId()))
                 .email(member.getEmail())
                 .name(member.getNickname())
                 .build();

--- a/src/main/java/com/project/backend/domain/event/dto/EventParticipantViewContext.java
+++ b/src/main/java/com/project/backend/domain/event/dto/EventParticipantViewContext.java
@@ -1,0 +1,14 @@
+package com.project.backend.domain.event.dto;
+
+import com.project.backend.domain.event.entity.EventParticipant;
+
+import java.util.List;
+import java.util.Map;
+
+public record EventParticipantViewContext(
+        List<EventParticipant> participants,
+        boolean isOwner,
+        boolean isAcceptedParticipant,
+        Map<Long, Long> friendIdByMemberId
+) {
+}

--- a/src/main/java/com/project/backend/domain/event/dto/response/EventResDTO.java
+++ b/src/main/java/com/project/backend/domain/event/dto/response/EventResDTO.java
@@ -1,6 +1,7 @@
 package com.project.backend.domain.event.dto.response;
 
 import com.project.backend.domain.event.enums.EventColor;
+import com.project.backend.domain.event.enums.InviteStatus;
 import lombok.Builder;
 
 import java.time.LocalDateTime;
@@ -31,6 +32,7 @@ public class EventResDTO {
             EventColor color,
             Boolean isShared,
             RecurrenceGroupResDTO.DetailRes recurrenceGroup,
+            Boolean isOwner,
             List<EventParticipantInfo> eventParticipantInfo
     ) {
     }
@@ -44,6 +46,8 @@ public class EventResDTO {
     @Builder
     public record EventParticipantInfo(
             Long eventParticipantId,
+            InviteStatus status,
+            Long friendId,
             String email,
             String name
     ) {

--- a/src/main/java/com/project/backend/domain/event/exception/EventErrorCode.java
+++ b/src/main/java/com/project/backend/domain/event/exception/EventErrorCode.java
@@ -36,6 +36,7 @@ public enum EventErrorCode implements BaseErrorCode {
     EVENT_INVITATION_FORBIDDEN(HttpStatus.FORBIDDEN, "EVENT403_1", "해당 일정 공유 초대에 대한 권한이 없습니다"),
 
     EVENT_OWNER_CANNOT_LEAVE(HttpStatus.FORBIDDEN, "EVENT403_2", "이벤트 소유자는 이벤트를 떠날 수 없습니다"),
+    EVENT_ACCESS_DENIED(HttpStatus.FORBIDDEN, "EVENT403_3", "이벤트 소유자가 아닌 사람은 수정할 수 없습니다"),
     ;
 
 

--- a/src/main/java/com/project/backend/domain/event/service/EventOccurrenceResolver.java
+++ b/src/main/java/com/project/backend/domain/event/service/EventOccurrenceResolver.java
@@ -19,6 +19,7 @@ import org.springframework.stereotype.Component;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import static com.project.backend.domain.common.recurrence.enums.ExceptionType.OVERRIDE;
@@ -38,15 +39,19 @@ public class EventOccurrenceResolver {
     public EventResDTO.DetailRes resolveForRead(
             Event event,
             LocalDateTime occurrenceDate,
-            List<EventParticipant> participants
+            List<EventParticipant> participants,
+            Boolean isOwner,
+            Map<Long, Long> friendIdByMemberId
     ) {
         ResolvedOccurrence ro = resolveInternal(event, occurrenceDate);
 
         if (ro.exception() != null) {
-            return EventConverter.toDetailRes(ro.event(), ro.exception(), ro.occurrenceDate(), participants);
+            return EventConverter.toDetailRes(
+                    ro.event(), ro.exception(), ro.occurrenceDate(), participants, isOwner, friendIdByMemberId);
         }
 
-        return EventConverter.toDetailRes(ro.event(), ro.occurrenceDate(), participants);
+        return EventConverter.toDetailRes(ro.event(),
+                ro.occurrenceDate(), participants, isOwner, friendIdByMemberId);
     }
 
     public void assertOccurrenceExists(Event event, LocalDateTime occurrenceDate) {

--- a/src/main/java/com/project/backend/domain/event/service/command/EventCommandServiceImpl.java
+++ b/src/main/java/com/project/backend/domain/event/service/command/EventCommandServiceImpl.java
@@ -136,17 +136,18 @@ public class EventCommandServiceImpl implements EventCommandService {
             RecurrenceUpdateScope scope,
             LocalDateTime occurrenceDate
     ) {
-        // 변경 사항 전혀 없음
-        if (!hasAnyEventFieldProvided(req) && !hasAnyRecurrenceGroupFieldProvided(req.recurrenceGroup())) {
-            log.info("1.Event update request is not changed. eventId: {}", eventId);
-            return;
-        }
 
         Event event = eventRepository.findById(eventId)
                 .orElseThrow(() -> new EventException(EventErrorCode.EVENT_NOT_FOUND));
 
         if (!Objects.equals(event.getMember().getId(), memberId)) {
             throw new EventException(EventErrorCode.EVENT_ACCESS_DENIED);
+        }
+
+        // 변경 사항 전혀 없음
+        if (!hasAnyEventFieldProvided(req) && !hasAnyRecurrenceGroupFieldProvided(req.recurrenceGroup())) {
+            log.info("1.Event update request is not changed. eventId: {}", eventId);
+            return;
         }
 
         // occurrenceDate가 없으면 event의 startTime을 기본값으로 사용

--- a/src/main/java/com/project/backend/domain/event/service/command/EventCommandServiceImpl.java
+++ b/src/main/java/com/project/backend/domain/event/service/command/EventCommandServiceImpl.java
@@ -142,8 +142,12 @@ public class EventCommandServiceImpl implements EventCommandService {
             return;
         }
 
-        Event event = eventRepository.findByIdAndMemberId(eventId, memberId)
+        Event event = eventRepository.findById(eventId)
                 .orElseThrow(() -> new EventException(EventErrorCode.EVENT_NOT_FOUND));
+
+        if (!Objects.equals(event.getMember().getId(), memberId)) {
+            throw new EventException(EventErrorCode.EVENT_ACCESS_DENIED);
+        }
 
         // occurrenceDate가 없으면 event의 startTime을 기본값으로 사용
         if (occurrenceDate == null) {

--- a/src/main/java/com/project/backend/domain/event/service/query/EventQueryServiceImpl.java
+++ b/src/main/java/com/project/backend/domain/event/service/query/EventQueryServiceImpl.java
@@ -1,7 +1,10 @@
 package com.project.backend.domain.event.service.query;
 
+import com.project.backend.domain.event.dto.EventParticipantViewContext;
 import com.project.backend.domain.event.entity.EventParticipant;
 import com.project.backend.domain.event.enums.InviteStatus;
+import com.project.backend.domain.friend.dto.FriendIdMapping;
+import com.project.backend.domain.friend.repository.FriendRepository;
 import com.project.backend.domain.occurrence.dto.TodayOccurrenceResult;
 import com.project.backend.domain.event.converter.EventConverter;
 import com.project.backend.domain.event.converter.EventHistoryConverter;
@@ -31,6 +34,7 @@ import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.*;
+import java.util.stream.Collectors;
 
 import static com.project.backend.domain.common.recurrence.enums.ExceptionType.OVERRIDE;
 import static com.project.backend.domain.common.recurrence.enums.ExceptionType.SKIP;
@@ -44,6 +48,7 @@ public class EventQueryServiceImpl implements EventQueryService {
     private static final int MAX_OCCURRENCE_ITERATION = 20_000;
 
     private final EventRepository eventRepository;
+    private final FriendRepository friendRepository;
     private final RecurrenceGroupRepository recurrenceGroupRepository;
     private final RecurrenceExceptionRepository recurrenceExceptionRepository;
 
@@ -59,29 +64,27 @@ public class EventQueryServiceImpl implements EventQueryService {
         Event event = eventRepository.findById(eventId)
                 .orElseThrow(() -> new EventException(EventErrorCode.EVENT_NOT_FOUND));
 
-        // 조회에 사용할 참여자들 목록
-        List<EventParticipant> participants =
-                eventParticipantRepository.findAllByEventId(eventId);
+        EventParticipantViewContext participantContext = getParticipantViewContext(event, memberId);
 
-        boolean isOwner = Objects.equals(event.getMember().getId(), memberId);
-
-        boolean isAcceptedParticipant = participants.stream()
-                .anyMatch(p ->
-                        Objects.equals(p.getMember().getId(), memberId)
-                                && p.getStatus() == InviteStatus.ACCEPTED
-                );
-
-        if (!isOwner && !isAcceptedParticipant) {
-            throw new EventException(EventErrorCode.EVENT_NOT_FOUND);
-        }
         eventValidator.validateRead(event, occurrenceDate);
 
         // 찾고자 하는 것이 부모 이벤트인 경우
         if (!event.isRecurring()) {
-            return EventConverter.toDetailRes(event, participants);
+            return EventConverter.toDetailRes(
+                    event,
+                    participantContext.participants(),
+                    participantContext.isOwner(),
+                    participantContext.friendIdByMemberId()
+            );
         }
 
-        return eventOccurrenceResolver.resolveForRead(event, occurrenceDate, participants);
+        return eventOccurrenceResolver.resolveForRead(
+                event,
+                occurrenceDate,
+                participantContext.participants(),
+                participantContext.isOwner(),
+                participantContext.friendIdByMemberId()
+        );
     }
 
     @Override
@@ -94,13 +97,15 @@ public class EventQueryServiceImpl implements EventQueryService {
 
         // 범위에 맞는 내가 소유자인 이벤트 목록 조회
         List<Event> OwnedEvents = getOwnedEvents(memberId, startRange, endRange);
+        log.info("Owned Events size: {}", OwnedEvents.toArray());
         // 범위에 맞는 내가 참여한 이벤트 목록 조회
         List<Event> SharedEvents = getSharedEvents(memberId, startRange, endRange);
+        log.info("Shared Events size: {}", SharedEvents.toArray());
         // 두 목록 병합
         List<Event> result = concatEventList(OwnedEvents, SharedEvents);
 
         // 최상위 이벤트 확장
-        List<EventResDTO.DetailRes> eventsListRes = expandEvents(result, startRange, endRange);
+        List<EventResDTO.DetailRes> eventsListRes = expandEvents(result, startRange, endRange, memberId);
 
         // 시작 날짜 기준으로 정렬
         eventsListRes.sort(
@@ -366,7 +371,8 @@ public class EventQueryServiceImpl implements EventQueryService {
     private List<EventResDTO.DetailRes> expandEvents(
             List<Event> baseEvents,
             LocalDateTime startRange,
-            LocalDateTime endRange
+            LocalDateTime endRange,
+            Long memberId
     ) {
 
         List<EventResDTO.DetailRes> expandedEvents = new ArrayList<>();
@@ -377,9 +383,12 @@ public class EventQueryServiceImpl implements EventQueryService {
             // 반복 패턴에 맞는 정지 조건 전략 주입
             EndCondition endCondition = endConditionFactory.getEndCondition(event.getRecurrenceGroup());
 
-            // 각 이벤트 객체별 참여자들 목록
-            List<EventParticipant> participants =
-                    eventParticipantRepository.findAllByEventId(event.getId());
+            EventParticipantViewContext participantContext =
+                    getParticipantViewContext(event, memberId);
+
+            List<EventParticipant> participants = participantContext.participants();
+            boolean isOwner = participantContext.isOwner();
+            Map<Long, Long> friendIdByMemberId = participantContext.friendIdByMemberId();
 
             // 익셉션 테이블 찾기
             List<RecurrenceException> recurrenceExceptions = new ArrayList<>();
@@ -411,12 +420,12 @@ public class EventQueryServiceImpl implements EventQueryService {
                 // 부모가 검색 범위에 포함되어 있지 않다면 시간만 추출하고 폐기
                 if (!isSkip && !tempStartTime.isBefore(startRange) && !tempEndTime.isAfter(endRange)) {
                     log.debug("예외 부모가 범위에 포함되었습니다");
-                    expandedEvents.add(EventConverter.toDetailRes(tempEx, event, participants));
+                    expandedEvents.add(EventConverter.toDetailRes(tempEx, event, participants, isOwner, friendIdByMemberId));
                 }
             } else {
                 if (!tempStartTime.isBefore(startRange) && !tempEndTime.isAfter(endRange)) {
                     log.debug("원본 부모가 범위에 포함되었습니다");
-                    expandedEvents.add(EventConverter.toDetailRes(event, participants));
+                    expandedEvents.add(EventConverter.toDetailRes(event, participants, isOwner, friendIdByMemberId));
                 }
             }
 
@@ -446,7 +455,7 @@ public class EventQueryServiceImpl implements EventQueryService {
                         current = generator.next(current, event.getRecurrenceGroup());
                     } else if (ex.getExceptionType() == OVERRIDE && current.isEqual(ex.getExceptionDate())) {
                         // 잘 찾았으니 리턴값에 추가
-                        expandedEvents.add(EventConverter.toDetailRes(ex, event, participants));
+                        expandedEvents.add(EventConverter.toDetailRes(ex, event, participants, isOwner, friendIdByMemberId));
                         current = generator.next(current, event.getRecurrenceGroup());
                     }
                 }
@@ -466,7 +475,7 @@ public class EventQueryServiceImpl implements EventQueryService {
                     break;
                 }
                 // 모든 탈출 조건을 통과한 객체는 DTO로 변환
-                expandedEvents.add(EventConverter.toDetailRes(event, current, current.plus(duration), participants));
+                expandedEvents.add(EventConverter.toDetailRes(event, current, current.plus(duration), participants, isOwner, friendIdByMemberId));
                 // 카운트 증가
                 count++;
             }
@@ -563,5 +572,56 @@ public class EventQueryServiceImpl implements EventQueryService {
         }
 
         return lastValid;
+    }
+
+    private EventParticipantViewContext getParticipantViewContext(Event event, Long memberId) {
+        List<EventParticipant> participants =
+                eventParticipantRepository.findAllByEventId(event.getId());
+
+        boolean isOwner = Objects.equals(event.getMember().getId(), memberId);
+
+        boolean isAcceptedParticipant = participants.stream()
+                .anyMatch(participant ->
+                        Objects.equals(participant.getMember().getId(), memberId)
+                                && participant.getStatus() == InviteStatus.ACCEPTED
+                );
+
+        Map<Long, Long> friendIdByMemberId = isOwner
+                ? getFriendIdByMemberId(memberId, participants)
+                : Map.of();
+
+        return new EventParticipantViewContext(
+                participants,
+                isOwner,
+                isAcceptedParticipant,
+                friendIdByMemberId
+        );
+    }
+
+    private Map<Long, Long> getFriendIdByMemberId(
+            Long memberId,
+            List<EventParticipant> participants
+    ) {
+        if (participants == null || participants.isEmpty()) {
+            return Map.of();
+        }
+
+        List<Long> participantMemberIds = participants.stream()
+                .map(participant -> participant.getMember().getId())
+                .distinct()
+                .toList();
+
+        if (participantMemberIds.isEmpty()) {
+            return Map.of();
+        }
+
+        return friendRepository
+                .findFriendIdsByMemberIdAndOpponentMemberIds(memberId, participantMemberIds)
+                .stream()
+                .collect(Collectors.toMap(
+                        FriendIdMapping::opponentMemberId,
+                        FriendIdMapping::friendId,
+                        (existing, replacement) -> existing
+                ));
     }
 }

--- a/src/main/java/com/project/backend/domain/friend/dto/FriendIdMapping.java
+++ b/src/main/java/com/project/backend/domain/friend/dto/FriendIdMapping.java
@@ -1,0 +1,7 @@
+package com.project.backend.domain.friend.dto;
+
+public record FriendIdMapping(
+        Long friendId,
+        Long opponentMemberId
+) {
+}

--- a/src/main/java/com/project/backend/domain/friend/repository/FriendRepository.java
+++ b/src/main/java/com/project/backend/domain/friend/repository/FriendRepository.java
@@ -1,5 +1,6 @@
 package com.project.backend.domain.friend.repository;
 
+import com.project.backend.domain.friend.dto.FriendIdMapping;
 import com.project.backend.domain.friend.entity.Friend;
 import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -71,5 +72,21 @@ public interface FriendRepository extends JpaRepository<Friend, Long> {
     Set<Long> findOpponentMemberIdsByFriendIds(
             @Param("friendIds") List<Long> friendIds,
             @Param("memberId") Long memberId
+    );
+
+    // 현재 로그인 사용자 memberId 기준으로
+    // 참여자들의 memberId에 해당하는 Friend row id를 한 번에 가져온다.
+    @Query("""
+    select new com.project.backend.domain.friend.dto.FriendIdMapping(
+        f.id,
+        f.opponent.id
+    )
+    from Friend f
+    where f.member.id = :memberId
+      and f.opponent.id in :opponentMemberIds
+""")
+    List<FriendIdMapping> findFriendIdsByMemberIdAndOpponentMemberIds(
+            @Param("memberId") Long memberId,
+            @Param("opponentMemberIds") List<Long> opponentMemberIds
     );
 }


### PR DESCRIPTION
# ☝️Issue Number

Close #194 

##  📌 개요

- 6834d2f628fc5aff96724f8cc2dae649ec51b965
  - 이벤트 상세 조회시 isOwner, friendId를 반환합니다
  - 만약 해당 Event의 소유자가 상세 조회를 한 경우, friendId를 반환합니다
  - 만약 해당 Event의 피공유자가 상세 조회를 한 경우, friendId는 null로 반환됩니다
<img width="358" height="196" alt="image" src="https://github.com/user-attachments/assets/bec1291c-7cbc-4dbc-8485-59087fff8aac" />

- 8b5911824234fb5882339d81d6debad95b65138d
  - 이제 더 이상 수정 권한이 없는 Event 객체를 수정하려고 하면 404가 아닌 403을 반환합니다

- e1089b55b7ad6e5cbb08a1a42975083b584eb174
  - "변경점 없음" 검증을 404, 403 검증 이후에 시도합니다
  

## 🔁 변경 사항

## 📸 스크린샷

## 👀 기타 더 이야기해볼 점
