### PR TITLE
✨feat: 참여자인 일정에 대해서도 오늘의 브리핑 반환 결과로 추가하도록 구현

### DIFF
--- a/src/main/java/com/project/backend/domain/briefing/service/query/BriefingQueryServiceImpl.java
+++ b/src/main/java/com/project/backend/domain/briefing/service/query/BriefingQueryServiceImpl.java
@@ -1,6 +1,8 @@
 package com.project.backend.domain.briefing.service.query;
 
 import com.project.backend.domain.briefing.converter.BriefingConverter;
+import com.project.backend.domain.event.enums.InviteStatus;
+import com.project.backend.domain.event.repository.EventParticipantRepository;
 import com.project.backend.domain.occurrence.dto.TodayOccurrenceResult;
 import com.project.backend.domain.briefing.enums.BriefingReason;
 import com.project.backend.domain.event.repository.EventRepository;
@@ -33,14 +35,17 @@ public class BriefingQueryServiceImpl implements BriefingQueryService {
     private final SettingRepository settingRepository;
     private final EventRepository eventRepository;
     private final TodoRepository todoRepository;
+    private final EventParticipantRepository eventParticipantRepository;
     private final OccurrenceResolver occurrenceResolver;
 
+    @Override
     public BriefingResDTO.BriefingRes getBriefing(Long memberId) {
         Setting setting = settingRepository.findByMemberId(memberId)
                 .orElseThrow(() -> new SettingException(SettingErrorCode.SETTING_NOT_FOUND));
 
         LocalDateTime now = LocalDateTime.now();
         LocalDate today = now.toLocalDate();
+        LocalDateTime endOfToday = today.atTime(LocalTime.MAX);
 
         // 브리핑 비활성화 시
         if (!setting.getDailyBriefing()) {
@@ -52,18 +57,38 @@ public class BriefingQueryServiceImpl implements BriefingQueryService {
 //            return BriefingConverter.toBriefingRes(today, BriefingReason.TIME_NOT_REACHED);
 //        }
 
-        // 현재시간보다 startTime이 이후가 아닌 일정/투두 조회
-        List<Long> eventIds = eventRepository.findEventIdsByMemberIdAndCurrentDate(
-                        memberId, today.atTime(LocalTime.MAX));
+        // 내가 주인인 일정
+        List<Long> ownedEventIds =
+                eventRepository.findEventIdsByMemberIdAndCurrentDate(
+                        memberId,
+                        endOfToday
+                );
 
-        List<Long> todoIds = todoRepository.findTodoIdsByMemberIdAndCurrentDate(memberId, today);
+        // 내가 ACCEPTED 참여자인 공유 일정
+        List<Long> acceptedSharedEventIds =
+                eventParticipantRepository.findEventIdsByParticipantMemberIdAndStatusAndCurrentDate(
+                        memberId,
+                        InviteStatus.ACCEPTED,
+                        endOfToday
+                );
+
+        // 소유 일정 + 공유받은 확정 일정 병합
+        List<Long> eventIds = Stream.concat(
+                        ownedEventIds.stream(),
+                        acceptedSharedEventIds.stream()
+                )
+                .distinct()
+                .toList();
+
+        List<Long> todoIds =
+                todoRepository.findTodoIdsByMemberIdAndCurrentDate(memberId, today);
 
         List<BriefingResDTO.BriefInfoRes> eventBrief =
                 eventIds.isEmpty() ? List.of() : toBriefInfos(TargetType.EVENT, eventIds, today);
-        List<BriefingResDTO.BriefInfoRes> todoBrief =
-                todoIds.isEmpty() ? List.of() : toBriefInfos(TargetType.TODO,  todoIds, today);
 
-        // 일정과 할일이 없다면 빈 값 리턴
+        List<BriefingResDTO.BriefInfoRes> todoBrief =
+                todoIds.isEmpty() ? List.of() : toBriefInfos(TargetType.TODO, todoIds, today);
+
         if (eventBrief.isEmpty() && todoBrief.isEmpty()) {
             return BriefingConverter.toBriefingRes(today, BriefingReason.NOT_EVENT_TODAY);
         }

--- a/src/main/java/com/project/backend/domain/event/repository/EventParticipantRepository.java
+++ b/src/main/java/com/project/backend/domain/event/repository/EventParticipantRepository.java
@@ -106,4 +106,18 @@ public interface EventParticipantRepository extends JpaRepository<EventParticipa
             "WHERE ep.member.id = :opponentId " +
             "AND ep.owner.id = :memberId")
     List<EventParticipant> findByMemberIdAndOpponentId(Long memberId, Long opponentId);
+
+    @Query("""
+    select distinct ep.event.id
+    from EventParticipant ep
+    join ep.event e
+    where ep.member.id = :memberId
+      and ep.status = :status
+      and e.startTime <= :endOfToday
+""")
+    List<Long> findEventIdsByParticipantMemberIdAndStatusAndCurrentDate(
+            @Param("memberId") Long memberId,
+            @Param("status") InviteStatus status,
+            @Param("endOfToday") LocalDateTime endOfToday
+    );
 }


### PR DESCRIPTION
# ☝️Issue Number

Close #196 

##  📌 개요

73f170006a4de47429f374f11f37c0608b955335
-  참여자인 일정에 대해서도 오늘의 브리핑 반환 결과로 추가하도록 구현

## 🔁 변경 사항
기존 오늘의 브리핑 조회 api는 해당 일정을 만든 memberId 대상으로 조회였지만,
변경된 오늘의 브리핑 조회 api는 기존 + 본인이 참여자인 일정도 검색하여 오늘의 브리핑으로 반환하도록 변경되었습니다.
## 📸 스크린샷

## 👀 기타 더 이야기해볼 점
