### PR TITLE
🐛fix: reminder 삭제 시 쿼리 파라미터 바인딩 오류 수정

### DIFF
--- a/src/main/java/com/project/backend/domain/reminder/repository/ReminderRepository.java
+++ b/src/main/java/com/project/backend/domain/reminder/repository/ReminderRepository.java
@@ -4,7 +4,7 @@ import com.project.backend.domain.reminder.entity.Reminder;
 import com.project.backend.domain.reminder.enums.LifecycleStatus;
 import com.project.backend.domain.reminder.enums.ReminderRole;
 import com.project.backend.domain.reminder.enums.TargetType;
-import io.lettuce.core.dynamic.annotation.Param;
+import org.springframework.data.repository.query.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -73,8 +73,7 @@ public interface ReminderRepository extends JpaRepository<Reminder, Long> {
     @Query("DELETE FROM Reminder r " +
             "WHERE r.targetId = :targetId " +
             "AND r.targetType = :type " +
-            "AND r.occurrenceTime >= :occurrenceTime " +
-            "AND r.member.id = :memberId")
+            "AND r.occurrenceTime >= :occurrenceTime")
     void deleteByTargetIdAndTargetTypeAndOccurrenceTime(
             @Param("targetId") Long targetId,
             @Param("type") TargetType type,


### PR DESCRIPTION
# ☝️Issue Number

Close #203 

##  📌 개요
### 오류 요약

`No argument for named parameter ':memberId'`
→ TODO/이벤트 삭제 시 500 Internal Server Error 발생

### 원인 1 : 쿼리 파라미터 불일치

ReminderRepository의 deleteByTargetIdAndTargetTypeAndOccurrenceTime 메서드에서, @Query 안에 AND r.member.id = :memberId 조건이 있지만 메서드 시그니처에는 memberId 파라미터가 없어 바인딩 실패

### 원인 2 : 잘못된 @Param import

@Param이 io.lettuce.core.dynamic.annotation.Param (Redis/Lettuce 라이브러리)으로 잘못 import되어 있음. Spring Data JPA에서는 org.springframework.data.repository.query.Param 사용 필요.

## 🔁 변경 사항

## 📸 스크린샷
<img width="823" height="456" alt="image" src="https://github.com/user-attachments/assets/55152089-f214-4c2b-a23d-f7468f23ec27" />

삭제 확인 완료.

## 👀 기타 더 이야기해볼 점
